### PR TITLE
sh3: match four sewer_00 funcs

### DIFF
--- a/silent-hill-3/src/Event/sewer_00.c
+++ b/silent-hill-3/src/Event/sewer_00.c
@@ -11,7 +11,7 @@ int func_01F6D680_sewer_00(void) {
     func_00316C50(0);
     func_0016ECE0(2);
     func_001C2290(2, 0.0f);
-    D_01F6FE00_sewer_00 += 1;
+    D_01F6FE00_sewer_00++;
   }
 
   ret = func_0016C540(D_01F6FB60_sewer_00, D_01F6FBC0_sewer_00);
@@ -83,7 +83,7 @@ int func_01F6D980_sewer_00(void) {
   case 0:
     func_0016C3C0();
     func_00190A20(2);
-    D_01F6FE60_sewer_00 += 1;
+    D_01F6FE60_sewer_00++;
     func_00317420(0x34);
     SeCall(1.0f, 0.0f, 0x2B21);
   case 1:
@@ -91,7 +91,7 @@ int func_01F6D980_sewer_00(void) {
       return 0;
     }
     func_0016C3C0();
-    D_01F6FE60_sewer_00 += 1;
+    D_01F6FE60_sewer_00++;
     SeCall(1.0f, 0.0f, 0x2B21);
     func_00317490(0x34, 0.2f);
   case 2:
@@ -101,12 +101,10 @@ int func_01F6D980_sewer_00(void) {
     func_00190A20(0);
     D_01F6FE60_sewer_00 = 0;
     func_003174B0(0.2f);
-    goto ret1;
+    break;
   }
 
-  goto ret1;
 
-ret1:
   return 1;
 }
 
@@ -114,90 +112,89 @@ int func_01F6DAB0_sewer_00(void) {
   sceVu0FMATRIX sp10;
   SubCharacter *heather;
 
-loop:
+  while (1) {
   switch (D_01F6FE20_sewer_00) {
-  case 0:
-    func_00190A20(2);
-    if ((D_1D31664 >> 2) & 1) {
-      func_001C2290(2, 0.0f);
-      D_01F6FE20_sewer_00 = 3;
-      goto loop;
-    }
-    D_01F6FE20_sewer_00 += 1;
-  case 1:
-    if (func_0016C1C0(0x19) == 0) {
-      return 0;
-    }
-    func_0016C3C0();
-    if (func_0016CB70() == 0) {
-      if ((D_1D31660 >> 21) & 1) {
-        func_001C2290(3, 0.8f);
+    case 0:
+      func_00190A20(2);
+      if ((D_1D31664 >> 2) & 1) {
+        func_001C2290(2, 0.0f);
         D_01F6FE20_sewer_00 = 3;
-        func_0013D250(0, D_01F6F9F0_sewer_00, 1.0f);
-        D_1D31664 |= 4;
-        func_00316C50(0);
-        SeCall(1.0f, 0.0f, 0x3200);
-        D_01F6FE30_sewer_00 = func_0016E0F0();
-        goto loop;
+        continue;
       }
-      D_01F6FE20_sewer_00 += 1;
-      goto loop;
-    }
-    D_01F6FE20_sewer_00 = 4;
-    goto loop;
-  case 2:
-    if ((D_1D31660 >> 24) & 1) {
-      if (func_0016C1C0(0x1B) == 0) {
+      D_01F6FE20_sewer_00++;
+    case 1:
+      if (func_0016C1C0(0x19) == 0) {
         return 0;
       }
       func_0016C3C0();
+      if (func_0016CB70() == 0) {
+        if ((D_1D31660 >> 21) & 1) {
+          func_001C2290(3, 0.8f);
+          D_01F6FE20_sewer_00 = 3;
+          func_0013D250(0, D_01F6F9F0_sewer_00, 1.0f);
+          D_1D31664 |= 4;
+          func_00316C50(0);
+          SeCall(1.0f, 0.0f, 0x3200);
+          D_01F6FE30_sewer_00 = func_0016E0F0();
+          continue;
+        }
+        D_01F6FE20_sewer_00++;
+        continue;
+      }
       D_01F6FE20_sewer_00 = 4;
-      goto loop;
-    } else {
-      if (func_0016C1C0(0x1A) == 0) {
+      continue;
+    case 2:
+      if ((D_1D31660 >> 24) & 1) {
+        if (func_0016C1C0(0x1B) == 0) {
+          return 0;
+        }
+        func_0016C3C0();
+        D_01F6FE20_sewer_00 = 4;
+        continue;
+      } else {
+        if (func_0016C1C0(0x1A) == 0) {
+          return 0;
+        }
+        func_0016C3C0();
+        D_01F6FE20_sewer_00 = 4;
+        continue;
+      }
+    case 3:
+      if (func_0016C540(D_01F6FC00_sewer_00, D_01F6FC60_sewer_00) == 0) {
+        D_01F6FE28_sewer_00 = 1;
+        heather = shCharacterGetSubCharacter(HEATHER_CHARA_ID, -1);
+        func_001DC9E0(heather, 0);
+        if (func_001643C0() >= 10.0f) {
+          func_0013D250(0, D_01F6FA30_sewer_00, 1.0f);
+        }
         return 0;
       }
-      func_0016C3C0();
-      D_01F6FE20_sewer_00 = 4;
-      goto loop;
-    }
-  case 3:
-    if (func_0016C540(D_01F6FC00_sewer_00, D_01F6FC60_sewer_00) == 0) {
-      D_01F6FE28_sewer_00 = 1;
       heather = shCharacterGetSubCharacter(HEATHER_CHARA_ID, -1);
-      func_001DC9E0(heather, 0);
-      if (func_001643C0() >= 10.0f) {
-        func_0013D250(0, D_01F6FA30_sewer_00, 1.0f);
-      }
-      return 0;
+      func_001DC9E0(heather, 1);
+      func_0016D0E0(0x3202, D_01F6FE58_sewer_00);
+      D_01F6FE58_sewer_00 = -1;
+      func_0016E400(0x22, D_01F6FE30_sewer_00);
+      func_0013D280(0);
+      D_1D31644 |= 0x04000000;
+      D_1D31660 |= 0x00100000;
+      sceVu0UnitMatrix(sp10);
+      sp10[3][0] = 0.0f;
+      sp10[3][1] = 0.0f;
+      sp10[3][2] = 0.0f;
+      sp10[3][3] = 0.0f;
+      func_001C2A80(1, sp10);
+      func_001C2A80(2, sp10);
+      func_001C2A80(3, sp10);
+      D_01F6FE20_sewer_00 = 4;
+      func_001C2290(5, 0.8f);
+    case 4:
+      D_01F6FE28_sewer_00 = 0;
+      func_0016C3C0();
+      func_00190A20(0);
+      D_01F6FE20_sewer_00 = 0;
+      return 1;
     }
-    heather = shCharacterGetSubCharacter(HEATHER_CHARA_ID, -1);
-    func_001DC9E0(heather, 1);
-    func_0016D0E0(0x3202, D_01F6FE58_sewer_00);
-    D_01F6FE58_sewer_00 = -1;
-    func_0016E400(0x22, D_01F6FE30_sewer_00);
-    func_0013D280(0);
-    D_1D31644 |= 0x04000000;
-    D_1D31660 |= 0x00100000;
-    sceVu0UnitMatrix(sp10);
-    sp10[3][0] = 0.0f;
-    sp10[3][1] = 0.0f;
-    sp10[3][2] = 0.0f;
-    sp10[3][3] = 0.0f;
-    func_001C2A80(1, sp10);
-    func_001C2A80(2, sp10);
-    func_001C2A80(3, sp10);
-    D_01F6FE20_sewer_00 = 4;
-    func_001C2290(5, 0.8f);
-  case 4:
-    D_01F6FE28_sewer_00 = 0;
-    func_0016C3C0();
-    func_00190A20(0);
-    D_01F6FE20_sewer_00 = 0;
-    return 1;
   }
-
-  goto loop;
 }
 
 INCLUDE_ASM("asm/nonmatchings/Event/sewer_00", func_01F6DE40_sewer_00);

--- a/silent-hill-3/src/Event/sewer_00.c
+++ b/silent-hill-3/src/Event/sewer_00.c
@@ -1,12 +1,204 @@
-#include "common.h"
+#include "sewer_00.h"
 
-INCLUDE_ASM("asm/nonmatchings/Event/sewer_00", func_01F6D680_sewer_00);
+int func_01F6D680_sewer_00(void) {
+  int ret;
+  float t;
+  Q data0;
+  Q data1;
 
-INCLUDE_ASM("asm/nonmatchings/Event/sewer_00", func_01F6D870_sewer_00);
+  switch (D_01F6FE00_sewer_00) {
+  case 0:
+    func_00316C50(0);
+    func_0016ECE0(2);
+    func_001C2290(2, 0.0f);
+    D_01F6FE00_sewer_00 += 1;
+  }
 
-INCLUDE_ASM("asm/nonmatchings/Event/sewer_00", func_01F6D980_sewer_00);
+  ret = func_0016C540(D_01F6FB60_sewer_00, D_01F6FBC0_sewer_00);
+  t = func_001643C0();
 
-INCLUDE_ASM("asm/nonmatchings/Event/sewer_00", func_01F6DAB0_sewer_00);
+  if (t < 64.0f) {
+    func_0013D250(0, D_01F6F8F0_sewer_00, 1.0f);
+  }
+
+  switch (D_01F6FE00_sewer_00) {
+  case 1:
+    if (t >= 65.0f) {
+      func_0013D250(0, D_01F6F930_sewer_00, 1.0f);
+      D_01F6FE00_sewer_00++;
+    }
+    break;
+  case 2:
+    if (t >= 98.0f) {
+      func_0013D250(0, D_01F6F9A0_sewer_00, 1.0f);
+      D_01F6FE00_sewer_00++;
+    }
+    break;
+  }
+
+  if (func_001646F0() == 2) {
+    data0 = D_01F6FBE0_sewer_00;
+    data1 = D_01F6FE10_sewer_00;
+    func_001DA020(1, &data0, &data1);
+  }
+
+  if (ret != 0) {
+    func_0013D280(0);
+    D_01F6FE00_sewer_00 = 0;
+    func_001C2290(5, 0.8f);
+  }
+
+  return ret;
+}
+
+int func_01F6D870_sewer_00(void) {
+  switch (D_01F6FE00_sewer_00) {
+  case 0:
+    func_00190A20(2);
+    func_0016CD00(D_01F6FBF0_sewer_00);
+    func_001C2290(3, 0.8f);
+    D_01F6FE00_sewer_00 = 1;
+  case 1:
+    if (func_001C2580(2) == 0) {
+      return 0;
+    }
+    D_01F6FE00_sewer_00 = 2;
+    func_001C2290(5, 0.8f);
+  case 2:
+    if (func_0016BED0(0xC3, 0x22) == 0) {
+      return 0;
+    }
+    D_01F6FE00_sewer_00 = 3;
+    func_001C2290(5, 0.8f);
+  case 3:
+    func_00190A20(0);
+  default:
+    D_01F6FE00_sewer_00 = 0;
+    return 1;
+  }
+}
+
+int func_01F6D980_sewer_00(void) {
+  switch (D_01F6FE60_sewer_00) {
+  case 0:
+    func_0016C3C0();
+    func_00190A20(2);
+    D_01F6FE60_sewer_00 += 1;
+    func_00317420(0x34);
+    SeCall(1.0f, 0.0f, 0x2B21);
+  case 1:
+    if (func_0016C1C0(0x45) == 0) {
+      return 0;
+    }
+    func_0016C3C0();
+    D_01F6FE60_sewer_00 += 1;
+    SeCall(1.0f, 0.0f, 0x2B21);
+    func_00317490(0x34, 0.2f);
+  case 2:
+    if (func_0016C1C0(0x46) == 0) {
+      return 0;
+    }
+    func_00190A20(0);
+    D_01F6FE60_sewer_00 = 0;
+    func_003174B0(0.2f);
+    goto ret1;
+  }
+
+  goto ret1;
+
+ret1:
+  return 1;
+}
+
+int func_01F6DAB0_sewer_00(void) {
+  sceVu0FMATRIX sp10;
+  SubCharacter *heather;
+
+loop:
+  switch (D_01F6FE20_sewer_00) {
+  case 0:
+    func_00190A20(2);
+    if ((D_1D31664 >> 2) & 1) {
+      func_001C2290(2, 0.0f);
+      D_01F6FE20_sewer_00 = 3;
+      goto loop;
+    }
+    D_01F6FE20_sewer_00 += 1;
+  case 1:
+    if (func_0016C1C0(0x19) == 0) {
+      return 0;
+    }
+    func_0016C3C0();
+    if (func_0016CB70() == 0) {
+      if ((D_1D31660 >> 21) & 1) {
+        func_001C2290(3, 0.8f);
+        D_01F6FE20_sewer_00 = 3;
+        func_0013D250(0, D_01F6F9F0_sewer_00, 1.0f);
+        D_1D31664 |= 4;
+        func_00316C50(0);
+        SeCall(1.0f, 0.0f, 0x3200);
+        D_01F6FE30_sewer_00 = func_0016E0F0();
+        goto loop;
+      }
+      D_01F6FE20_sewer_00 += 1;
+      goto loop;
+    }
+    D_01F6FE20_sewer_00 = 4;
+    goto loop;
+  case 2:
+    if ((D_1D31660 >> 24) & 1) {
+      if (func_0016C1C0(0x1B) == 0) {
+        return 0;
+      }
+      func_0016C3C0();
+      D_01F6FE20_sewer_00 = 4;
+      goto loop;
+    } else {
+      if (func_0016C1C0(0x1A) == 0) {
+        return 0;
+      }
+      func_0016C3C0();
+      D_01F6FE20_sewer_00 = 4;
+      goto loop;
+    }
+  case 3:
+    if (func_0016C540(D_01F6FC00_sewer_00, D_01F6FC60_sewer_00) == 0) {
+      D_01F6FE28_sewer_00 = 1;
+      heather = shCharacterGetSubCharacter(HEATHER_CHARA_ID, -1);
+      func_001DC9E0(heather, 0);
+      if (func_001643C0() >= 10.0f) {
+        func_0013D250(0, D_01F6FA30_sewer_00, 1.0f);
+      }
+      return 0;
+    }
+    heather = shCharacterGetSubCharacter(HEATHER_CHARA_ID, -1);
+    func_001DC9E0(heather, 1);
+    func_0016D0E0(0x3202, D_01F6FE58_sewer_00);
+    D_01F6FE58_sewer_00 = -1;
+    func_0016E400(0x22, D_01F6FE30_sewer_00);
+    func_0013D280(0);
+    D_1D31644 |= 0x04000000;
+    D_1D31660 |= 0x00100000;
+    sceVu0UnitMatrix(sp10);
+    sp10[3][0] = 0.0f;
+    sp10[3][1] = 0.0f;
+    sp10[3][2] = 0.0f;
+    sp10[3][3] = 0.0f;
+    func_001C2A80(1, sp10);
+    func_001C2A80(2, sp10);
+    func_001C2A80(3, sp10);
+    D_01F6FE20_sewer_00 = 4;
+    func_001C2290(5, 0.8f);
+  case 4:
+    D_01F6FE28_sewer_00 = 0;
+    func_0016C3C0();
+    func_00190A20(0);
+    D_01F6FE20_sewer_00 = 0;
+    return 1;
+  }
+
+  goto loop;
+}
 
 INCLUDE_ASM("asm/nonmatchings/Event/sewer_00", func_01F6DE40_sewer_00);
 

--- a/silent-hill-3/src/Event/sewer_00.h
+++ b/silent-hill-3/src/Event/sewer_00.h
@@ -1,0 +1,77 @@
+#ifndef SEWER_00_H
+#define SEWER_00_H
+
+#include "common.h"
+#include "Chacter/m3_sc.h"
+
+void func_0013D250(int, int *, float);
+void func_0013D280(int);
+void func_001433A0(SubCharacter *, int, int);
+void func_001BE4B0(int);
+float func_001643C0(void);
+int func_001646F0(void);
+int func_0016BED0(int, int);
+int func_0016C1C0(int);
+void func_0016C3C0(void);
+int func_0016C540(int *, int *);
+void func_0016CA40(int);
+void func_0016CBD0(Q **, Q *, int);
+int func_0016CB70(void);
+void func_0016CC50(int, int, Q *, Q *);
+int func_001E2110(SubCharacter *);
+void func_0016CD00(int *);
+void func_0016D170(int, int (*)[4], int, int, float, float);
+void func_0016D0E0(int, int);
+int func_0016D240(int, int (*)[4], int, int, float, float);
+SubCharacter *shCharacterGetSubCharacter(int, short);
+void func_0016ECE0(int);
+int func_0016E0F0(void);
+void func_0016E400(int, int);
+int func_00190950(void);
+void func_00190A20(int);
+void func_001A06F0(void *);
+void func_001C2290(int, float);
+void func_001C2A80(int, sceVu0FMATRIX);
+int func_001C2580(int);
+void func_001DC9E0(SubCharacter *, int);
+void func_001DA020(int, Q *, Q *);
+void func_00316C50(int);
+void func_00317420(u_int);
+void func_00317490(int, float);
+void func_003174B0(float);
+int RoomName(void);
+u_char GetActionLevel(void);
+void SeCall(float, float, int);
+int shCharacter_Manage_Delete(u16, u16);
+
+extern int D_01F6F8F0_sewer_00[];
+extern int D_01F6F850_sewer_00[];
+extern int D_01F6F930_sewer_00[];
+extern int D_01F6F9A0_sewer_00[];
+extern int D_01F6F9F0_sewer_00[];
+extern int D_01F6FA30_sewer_00[];
+extern int D_01F6FB60_sewer_00[];
+extern int D_01F6FBC0_sewer_00[];
+extern int D_01F6FBF0_sewer_00[];
+extern int D_01F6FC00_sewer_00[];
+extern int D_01F6FC80_sewer_00[];
+extern int D_01F6FC98_sewer_00[];
+extern int D_01F6FCB0_sewer_00[4];
+extern int D_01F6FCC0_sewer_00[4];
+extern int D_01F6FC60_sewer_00[];
+extern Q D_01F6FBE0_sewer_00;
+extern int D_01F6FE00_sewer_00;
+extern int D_01F6FE20_sewer_00;
+extern int D_01F6FE28_sewer_00;
+extern int D_01F6FE30_sewer_00;
+extern Q D_01F6FE40_sewer_00;
+extern int D_01F6FE50_sewer_00;
+extern int D_01F6FE58_sewer_00;
+extern int D_01F6FE60_sewer_00;
+extern Q D_01F6FE10_sewer_00;
+extern u_int D_1D316AC;
+extern u_int D_1D31644;
+extern u_int D_1D31660;
+extern u_int D_1D31664;
+
+#endif


### PR DESCRIPTION
Hiya! I tried to do the thing!

I matched some of the functions in `sewer_00.c` for SH3. I have C code of the rest of the functions in that file but they are not 100%. 

What does one do when the only differences are compiler decisions? I learned about [decomp-permuter](https://github.com/simonlindholm/decomp-permuter) to brute force some of these problems but I am wondering where the limit is. For example, in the sewer ASM there's a few comments `/* Handwritten function */`. Does that mean handwritten ASM? Are there exist ASM programs that cannot be expressed in C because the ASM is written in a way that C compilerc won't express for you? What do projects aiming for 100% matching decomp do in that case?

This has been soo educational and I feel like I leveled something up lol thanks for providing such a good playground to do this in. It was easy to drop in and start.