### PR TITLE
sh3: fix mall mistake

### DIFF
--- a/silent-hill-3/src/Event/hospital_f_01.c
+++ b/silent-hill-3/src/Event/hospital_f_01.c
@@ -124,7 +124,7 @@ u_short func_01F6DB70_hospital_f_01(void) {
     float sp1C;
 
     func_0029F330(&sp18, &sp1C);
-    return func_002A47C0(sp18, sp1C) & 0xFFFF;
+    return func_002A47C0(sp18, sp1C);
 }
 
 INCLUDE_ASM("asm/nonmatchings/Event/hospital_f_01", func_01F6DBA0_hospital_f_01);
@@ -168,7 +168,7 @@ u_short func_01F6F690_hospital_f_01(void) {
     float sp1C;
 
     func_0029F330(&sp18, &sp1C);
-    return func_002A47C0(sp18, sp1C) & 0xFFFF;
+    return func_002A47C0(sp18, sp1C);
 }
 
 INCLUDE_ASM("asm/nonmatchings/Event/hospital_f_01", func_01F6F6C0_hospital_f_01);

--- a/silent-hill-3/src/Event/hospital_f_02.c
+++ b/silent-hill-3/src/Event/hospital_f_02.c
@@ -115,7 +115,7 @@ u_short func_01F6DC60_hospital_f_02(void) {
     float sp1C;
 
     func_0029F330(&sp18, &sp1C);
-    return func_002A47C0(sp18, sp1C) & 0xFFFF;
+    return func_002A47C0(sp18, sp1C);
 }
 
 INCLUDE_ASM("asm/nonmatchings/Event/hospital_f_02", func_01F6DC90_hospital_f_02);

--- a/silent-hill-3/src/Event/mall_b_00.h
+++ b/silent-hill-3/src/Event/mall_b_00.h
@@ -7,22 +7,7 @@ extern double func_0012AB58(double);
 extern double func_00124120(float);
 extern double func_0012B398(double);
 extern double func_001248A0(double, double);
-int func_001C2290(int, float);
-int func_002A47C0(float, float);
-extern Q D_01F72AB0_mall_f_01;
-extern int D_1D3164C;
-int func_0016C540(int*, int*);
-extern int D_01F72BB8_mall_f_01;
-extern int D_01F72BC8_mall_f_01;
-extern int D_01F72890_mall_f_01;
-extern int D_01F728F0_mall_f_01;
-extern u_int D_1D31650;
-extern int D_1D31700;
-extern int D_1D31784;
-
 extern void func_00124CD8(double);
-void func_0029F330(float*, float*);
-void func_002A2E70(Q*);
 int func_01F70720_mall_f_01(void);
 
 void shQzero(int*, int);

--- a/silent-hill-3/src/Event/mall_f_01.c
+++ b/silent-hill-3/src/Event/mall_f_01.c
@@ -1,5 +1,4 @@
-#include "common.h"
-#include "mall_b_00.h"
+#include "mall_f_01.h"
 
 INCLUDE_ASM("asm/nonmatchings/Event/mall_f_01", func_01F6D680_mall_f_01);
 

--- a/silent-hill-3/src/Event/mall_f_01.h
+++ b/silent-hill-3/src/Event/mall_f_01.h
@@ -1,0 +1,23 @@
+#ifndef MALL_F_01
+#define MALL_F_01
+
+#include "common.h"
+
+extern int D_1D3164C;
+extern u_int D_1D31650;
+extern int D_1D31700;
+extern int D_1D31784;
+extern int D_01F72BB8_mall_f_01;
+extern int D_01F72BC8_mall_f_01;
+extern int D_01F72890_mall_f_01;
+extern int D_01F728F0_mall_f_01;
+extern Q D_01F72AB0_mall_f_01;
+
+void func_002A2E70(Q*);
+int func_002A47C0(float, float);
+void func_0029F330(float*, float*);
+int func_01F70720_mall_f_01(void);
+int func_0016C540(int*, int*);
+int func_001C2290(int, float);
+
+#endif


### PR DESCRIPTION
This fixes a very dumb mistake I made in https://github.com/dreamingmoths/memory-of-alessa/pull/63

I also took the opportunity to "standardize" the "`return func_002A47C0(sp18, sp1C)`" wrapper functions that get repeated across some overlays by removing the `& 0xFFFF` mask as @dreamingmoths had done in https://github.com/dreamingmoths/memory-of-alessa/pull/64 for the ones in `mall_f_01`