### PR TITLE
alessatool: add `--tu` option to `annotate`

### DIFF
--- a/tools/alessatool/alessatool.py
+++ b/tools/alessatool/alessatool.py
@@ -176,6 +176,11 @@ def main():
         type=str,
         default="shift-jis"
     )
+    annotate_parser.add_argument(
+        "--tu",
+        action="store_true",
+        help="arrange each function into its own text section"
+    )
     annotate_parser.set_defaults(func=annotate)
 
     patch_parser = subparsers.add_parser(

--- a/tools/alessatool/annotate.py
+++ b/tools/alessatool/annotate.py
@@ -91,7 +91,7 @@ def annotate_asm(args: AnnotationArgs):
                     should_append_asm_line = False
                 
                 # remove `macro.inc` include directive
-                if asm_line_trimmed == INCLUDE_MACRO_INC_DIRECTIVE:
+                elif asm_line_trimmed == INCLUDE_MACRO_INC_DIRECTIVE:
                     should_append_asm_line = False
 
             if should_append_asm_line:

--- a/tools/alessatool/annotate.py
+++ b/tools/alessatool/annotate.py
@@ -1,7 +1,8 @@
+from sys import stdout
 from pathlib import Path
 from subprocess import run
 from dataclasses import dataclass
-import sys
+from constants import FUNCTION_SYMBOL_LABEL, END_FUNCTION_SYMBOL_LABEL, UNIQUE_TEXT_SECTION_DIRECTIVE
 
 @dataclass
 class AnnotationArgs:
@@ -11,6 +12,7 @@ class AnnotationArgs:
     asm_path: Path | None
     out_path: Path
     addr2line_path: Path
+    tu: bool
     encoding: str
     stdout: bool
     verbose: bool
@@ -29,15 +31,18 @@ def annotate_asm(args: AnnotationArgs):
 
     addresses = (f"0x{v:X}" for v in range(vram_start, vram_end, 0x4))
     proc = run([args.addr2line_path, "-e", args.elf_path, *addresses], capture_output=True, encoding=args.encoding)
-    lines = proc.stdout.splitlines()
+    addr2line_output_lines = proc.stdout.splitlines()
 
     prev_tu_name = ""
     prev_line_number = -1
+    function_count = 0
+    is_in_function_label = False
     current_vram_addr = vram_start
     annotated_asm_lines = []
 
-    for addr_index in range(0, len(lines) - 1):
-        line = lines[addr_index]
+    for addr_index in range(0, len(addr2line_output_lines) - 1):
+        line = addr2line_output_lines[addr_index]
+
         if line.startswith("?"):
             current_vram_addr += 0x4
             continue
@@ -68,7 +73,28 @@ def annotate_asm(args: AnnotationArgs):
             if line_has_vram_addr(asm_line, vram_addr_str):
                 break
 
-            annotated_asm_lines.append(asm_line)
+            should_append_asm_line = True
+            if args.tu:
+                # track when we go in & out of function symbols
+                if asm_line.startswith(FUNCTION_SYMBOL_LABEL):
+                    function_count += 1
+                    is_in_function_label = True
+                    annotated_asm_lines.append(f'{UNIQUE_TEXT_SECTION_DIRECTIVE}{function_count}')
+                    annotated_asm_lines.append("")
+                elif asm_line.startswith(END_FUNCTION_SYMBOL_LABEL):
+                    is_in_function_label = False
+
+                # remove `nop`s
+                if not is_in_function_label and asm_line.strip().endswith("nop"):
+                    should_append_asm_line = False
+                
+                # remove `macro.inc` include directive
+                if asm_line == '.include "macro.inc"':
+                    should_append_asm_line = False
+
+            if should_append_asm_line:
+                annotated_asm_lines.append(asm_line)
+
             asm_line_index += 1
 
         annotated_asm_lines.append(f"\t.loc 1 {current_line_number}")    
@@ -78,7 +104,7 @@ def annotate_asm(args: AnnotationArgs):
         prev_line_number = current_line_number
         current_vram_addr += 0x4
     
-    while asm_line_index < len(asm_lines):
+    while asm_line_index < len(asm_lines) - 1:
         annotated_asm_lines.append(asm_lines[asm_line_index])
         asm_line_index += 1
 
@@ -99,7 +125,7 @@ def annotate_asm(args: AnnotationArgs):
         if args.verbose:
             print(f"alessatool/annotate: wrote asm to {args.out_path}")
     else:
-        sys.stdout.write(annotated_asm_contents)
+        stdout.write(annotated_asm_contents)
 
 
 def find_vram_bounds(asm_lines: list[str]):

--- a/tools/alessatool/annotate.py
+++ b/tools/alessatool/annotate.py
@@ -171,7 +171,6 @@ def line_has_vram_addr(line: str, addr_str: str) -> bool:
 
     return line.index("*/") > line.index(addr_str)
 
-def append_final_new_line(lines: list[str]) -> str:
+def append_final_new_line(lines: list[str]):
     if lines[-1] != "":
         lines.append("")
-    return lines

--- a/tools/alessatool/annotate.py
+++ b/tools/alessatool/annotate.py
@@ -2,7 +2,7 @@ from sys import stdout
 from pathlib import Path
 from subprocess import run
 from dataclasses import dataclass
-from constants import FUNCTION_SYMBOL_LABEL, END_FUNCTION_SYMBOL_LABEL, UNIQUE_TEXT_SECTION_DIRECTIVE
+from constants import *
 
 @dataclass
 class AnnotationArgs:
@@ -89,7 +89,7 @@ def annotate_asm(args: AnnotationArgs):
                     should_append_asm_line = False
                 
                 # remove `macro.inc` include directive
-                if asm_line == '.include "macro.inc"':
+                if asm_line == INCLUDE_MACRO_INC_DIRECTIVE:
                     should_append_asm_line = False
 
             if should_append_asm_line:

--- a/tools/alessatool/annotate.py
+++ b/tools/alessatool/annotate.py
@@ -81,7 +81,7 @@ def annotate_asm(args: AnnotationArgs):
                 if asm_line_trimmed.startswith(FUNCTION_SYMBOL_LABEL):
                     function_count += 1
                     is_in_function_label = True
-                    annotated_asm_lines.append(f'{UNIQUE_TEXT_SECTION_DIRECTIVE}{function_count}')
+                    annotated_asm_lines.append(f"{UNIQUE_TEXT_SECTION_DIRECTIVE}{function_count}")
                     annotated_asm_lines.append("")
                 elif asm_line_trimmed.startswith(END_FUNCTION_SYMBOL_LABEL):
                     is_in_function_label = False

--- a/tools/alessatool/annotate.py
+++ b/tools/alessatool/annotate.py
@@ -75,21 +75,23 @@ def annotate_asm(args: AnnotationArgs):
 
             should_append_asm_line = True
             if args.tu:
+                asm_line_trimmed = asm_line.strip()
+
                 # track when we go in & out of function symbols
-                if asm_line.startswith(FUNCTION_SYMBOL_LABEL):
+                if asm_line_trimmed.startswith(FUNCTION_SYMBOL_LABEL):
                     function_count += 1
                     is_in_function_label = True
                     annotated_asm_lines.append(f'{UNIQUE_TEXT_SECTION_DIRECTIVE}{function_count}')
                     annotated_asm_lines.append("")
-                elif asm_line.startswith(END_FUNCTION_SYMBOL_LABEL):
+                elif asm_line_trimmed.startswith(END_FUNCTION_SYMBOL_LABEL):
                     is_in_function_label = False
 
                 # remove `nop`s
-                if not is_in_function_label and asm_line.strip().endswith("nop"):
+                if not is_in_function_label and asm_line_trimmed.endswith("nop"):
                     should_append_asm_line = False
                 
                 # remove `macro.inc` include directive
-                if asm_line == INCLUDE_MACRO_INC_DIRECTIVE:
+                if asm_line_trimmed == INCLUDE_MACRO_INC_DIRECTIVE:
                     should_append_asm_line = False
 
             if should_append_asm_line:
@@ -117,6 +119,7 @@ def annotate_asm(args: AnnotationArgs):
         *annotated_asm_lines
     ]
 
+    append_final_new_line(annotated_asm_lines)
     annotated_asm_contents = "\n".join(annotated_asm_lines)
 
     if not args.stdout and args.out_path:
@@ -167,3 +170,8 @@ def line_has_vram_addr(line: str, addr_str: str) -> bool:
         return False
 
     return line.index("*/") > line.index(addr_str)
+
+def append_final_new_line(lines: list[str]) -> str:
+    if lines[-1] != "":
+        lines.append("")
+    return lines

--- a/tools/alessatool/constants.py
+++ b/tools/alessatool/constants.py
@@ -14,3 +14,4 @@ ADDR2LINE_PATH = f"{TOOLS}/binutils-mips-ps2-decompals/mips-ps2-decompals-addr2l
 FUNCTION_SYMBOL_LABEL = "glabel"
 END_FUNCTION_SYMBOL_LABEL = "endlabel"
 UNIQUE_TEXT_SECTION_DIRECTIVE = '.section .text,"ax",@progbits,unique,'
+INCLUDE_MACRO_INC_DIRECTIVE = '.include "macro.inc"'

--- a/tools/alessatool/constants.py
+++ b/tools/alessatool/constants.py
@@ -10,3 +10,7 @@ ROM = "rom"
 SRC = "src"
 TOOLS = "tools"
 ADDR2LINE_PATH = f"{TOOLS}/binutils-mips-ps2-decompals/mips-ps2-decompals-addr2line"
+
+FUNCTION_SYMBOL_LABEL = "glabel"
+END_FUNCTION_SYMBOL_LABEL = "endlabel"
+UNIQUE_TEXT_SECTION_DIRECTIVE = '.section .text,"ax",@progbits,unique,'


### PR DESCRIPTION
adds a new option `--tu` that can be used to create whole tu scratches in decomp.me.

test like so:

```sh
alessatool annotate --asm-path silent-hill-2/config/SLUS_202.28/asm/Chacter/player_result.s --tu
```

after the usual setup:

```sh
make sh2-report -j
source tools/scripts/env.sh
```
