### PR TITLE
sh2: match 6 `view/vw_main.c`

### DIFF
--- a/include/vec.h
+++ b/include/vec.h
@@ -101,4 +101,19 @@ static inline float vec3_dot_product(void* v, void* w) {
     return d;
 }
 
+/* build 4x4 identity matrix using VU0 */
+static inline void vu0_unit_matrix(sceVu0FMATRIX out) {
+    asm("\
+        vsub.xyzw vf5, vf0, vf0\n\
+        vsub.xyzw vf6, vf0, vf0\n\
+        vmr32.xyzw vf4, vf0\n\
+        vaddw.y vf5, vf0, vf0\n\
+        vaddw.x vf6, vf0, vf0\n\
+        sqc2 vf0, 0x30(%0)\n\
+        sqc2 vf4, 0x20(%0)\n\
+        sqc2 vf5, 0x10(%0)\n\
+        sqc2 vf6, 0(%0)"
+        : "+r"(out));
+}
+
 #endif // SILENT_VEC_H

--- a/silent-hill-2/config/SLUS_202.28/SLUS_202.28.yaml
+++ b/silent-hill-2/config/SLUS_202.28/SLUS_202.28.yaml
@@ -148,7 +148,7 @@ segments:
       - [0x0960e0, asm, view/vc_main]
       - [0x09e490, asm, view/vc_util]
       - [0x09ed40, asm, view/vw_calc]
-      - [0x09f720, asm, view/vw_main]
+      - [0x09f720, c,   view/vw_main]
       - [0x09f9f0, c,   main]
       - [0x09fe30, asm, sh2gfw_all_sysinit]
       - [0x0a0280, asm, sh2gfw_drawloop_main]

--- a/silent-hill-2/src/view/vc_play.c
+++ b/silent-hill-2/src/view/vc_play.c
@@ -1,4 +1,6 @@
 #include "vc_play.h"
+#include "SH2_common/sh_vu0.h"
+#include "SH2_common/sh2dt.h"
 
 static inline float vec2_length(float* a, float* b) {
     float result;

--- a/silent-hill-2/src/view/vc_play.h
+++ b/silent-hill-2/src/view/vc_play.h
@@ -41,9 +41,6 @@ extern void GetPlayerPartsLocalMatrix(float (*mat)[4] /* r2 */, u_int parts_name
 extern void GetPlayerPartsWorldMatrix(float (*mat)[4] /* r2 */, u_int parts_name /* r2 */);
 extern float PlayerGetNeckAngleX(void);
 extern float PlayerGetNeckAngleY(void);
-extern float shAtan2(float, float);
-extern void shMulMatrix(float (*m0)[4] /* r2 */, float (*m1)[4] /* r2 */, float (*m2)[4] /* r2 */);
-extern float shGetFPS(void);
 
 extern struct shPlayerWork sh2jms;
 extern SYS_W sys;

--- a/silent-hill-2/src/view/vw_main.c
+++ b/silent-hill-2/src/view/vw_main.c
@@ -1,5 +1,6 @@
 #include "vw_main.h"
 #include "vec.h"
+#include "SH2_common/sh_vu0.h"
 
 #line 52
 void vwInitViewInfo(void) {
@@ -27,7 +28,7 @@ void vwGetViewAngle(sceVu0FVECTOR pos) {
 }
 
 #line 184
-void vwSetCoordRefAndEntou(VbCOORDINATE* parent_p, sceVu0FVECTOR ref, f32 cam_ang_y, f32 cam_ang_z, f32 cam_y, f32 cam_xz_r) {
+void vwSetCoordRefAndEntou(VbCOORDINATE* parent_p, sceVu0FVECTOR ref, float cam_ang_y, float cam_ang_z, float cam_y, float cam_xz_r) {
     sceVu0FVECTOR view_ang;
 
     vwViewPointInfo.vwcoord.flg = 0;
@@ -40,7 +41,7 @@ void vwSetCoordRefAndEntou(VbCOORDINATE* parent_p, sceVu0FVECTOR ref, f32 cam_an
 
 
     view_ang[0] *= -1.0f;
-    view_ang[1] += 3.1415927f;
+    view_ang[1] += PI;
 
     view_ang[0] = shAngleRegulate(view_ang[0]);
     view_ang[1] = shAngleRegulate(view_ang[1]);

--- a/silent-hill-2/src/view/vw_main.c
+++ b/silent-hill-2/src/view/vw_main.c
@@ -1,0 +1,72 @@
+#include "vw_main.h"
+#include "vec.h"
+
+#line 52
+void vwInitViewInfo(void) {
+    vec_zero(&vwViewPointInfo.rview.vp);
+    vec_zero(&vwViewPointInfo.rview.vr);
+    vwViewPointInfo.rview.vr[2] = 1.0f;
+
+    vwViewPointInfo.rview.rz = 0.0f;
+
+    vwViewPointInfo.rview.super = &vwViewPointInfo.vwcoord;
+
+    vbInitCoordinate(NULL, &vwViewPointInfo.vwcoord);
+
+    vwSetViewInfo();
+}
+
+#line 100
+void vwGetViewPosition(sceVu0FVECTOR pos) {
+    vec_copy(pos, vwViewPointInfo.worldpos);
+}
+
+#line 119
+void vwGetViewAngle(sceVu0FVECTOR pos) {
+    vec_copy(pos, vwViewPointInfo.worldang);
+}
+
+#line 184
+void vwSetCoordRefAndEntou(VbCOORDINATE* parent_p, sceVu0FVECTOR ref, f32 cam_ang_y, f32 cam_ang_z, f32 cam_y, f32 cam_xz_r) {
+    sceVu0FVECTOR view_ang;
+
+    vwViewPointInfo.vwcoord.flg = 0;
+    vwViewPointInfo.vwcoord.super = parent_p;
+
+    view_ang[0] = shAtan2(cam_xz_r, -cam_y);
+    view_ang[1] = cam_ang_y;
+    view_ang[2] = cam_ang_z;
+    view_ang[3] = 1.0f;
+
+
+    view_ang[0] *= -1.0f;
+    view_ang[1] += 3.1415927f;
+
+    view_ang[0] = shAngleRegulate(view_ang[0]);
+    view_ang[1] = shAngleRegulate(view_ang[1]);
+    view_ang[2] = shAngleRegulate(view_ang[2]);
+
+    vu0_unit_matrix(vwViewPointInfo.vwcoord.coord);
+    vwRotMatrixYXZ(view_ang, vwViewPointInfo.vwcoord.coord);
+
+    vwViewPointInfo.vwcoord.coord[3][0] = ref[0] + (cam_xz_r * shSinF(cam_ang_y));
+    vwViewPointInfo.vwcoord.coord[3][1] = ref[1] + cam_y;
+    vwViewPointInfo.vwcoord.coord[3][2] = ref[2] + (cam_xz_r * shCosF(cam_ang_y));
+}
+
+#line 227
+void vwSetViewInfo(void) {
+    vbSetRefView(&vwViewPointInfo.rview);
+
+
+
+    volatile_vec_copy(vwViewPointInfo.worldpos, vwViewPointInfo.vwcoord.lw[3]);
+
+    vwMatrixToAngleYXZ(vwViewPointInfo.worldang, vwViewPointInfo.vwcoord.lw);
+}
+
+#line 253
+void vwSetViewInfoDirectMatrix(VbCOORDINATE* pcoord, sceVu0FMATRIX cammat) {
+    vwViewPointInfo.vwcoord.flg = 0;
+    vwViewPointInfo.vwcoord.super = pcoord;
+    mat_copy(vwViewPointInfo.vwcoord.coord, cammat); } // @note: closing bracket needs to be here to match line number?

--- a/silent-hill-2/src/view/vw_main.h
+++ b/silent-hill-2/src/view/vw_main.h
@@ -23,16 +23,38 @@ typedef struct _VbCOORDINATE {
     sceVu0FVECTOR rot; // offset 0x130, size 0x10
 } VbCOORDINATE;
 
+typedef struct _VbRVIEW {
+    /* 0x00 */ sceVu0FVECTOR vp;
+    /* 0x10 */ sceVu0FVECTOR vr;
+    /* 0x20 */ float rz;
+    /* 0x24 */ VbCOORDINATE* super;
+} VbRVIEW;
+
+typedef struct _VW_VIEW_WORK {
+    /* 0x000 */ VbRVIEW rview;
+    /* 0x030 */ VbCOORDINATE vwcoord;
+    /* 0x170 */ sceVu0FVECTOR worldpos;
+    /* 0x180 */ sceVu0FVECTOR worldang;
+} VW_VIEW_WORK;
+
+extern VW_VIEW_WORK vwViewPointInfo;
+
 void vwInitViewInfo(void);
 
-void vwGetViewPosition(float* pos);
+void vwGetViewPosition(sceVu0FVECTOR pos);
 
-void vwGetViewAngle(float* ang);
+void vwGetViewAngle(sceVu0FVECTOR ang);
 
-void vwSetCoordRefAndEntou(VbCOORDINATE* parent_p, float* ref, float cam_ang_y, float cam_ang_z, float cam_y, float cam_xz_r);
+void vwSetCoordRefAndEntou(VbCOORDINATE* parent_p, sceVu0FVECTOR ref, float cam_ang_y, float cam_ang_z, float cam_y, float cam_xz_r);
 
 void vwSetViewInfo(void);
 
-void vwSetViewInfoDirectMatrix(VbCOORDINATE* pcoord, float (*cammat)[4]);
+void vwSetViewInfoDirectMatrix(VbCOORDINATE* pcoord, sceVu0FMATRIX cammat);
+
+// @todo: should just include sh_vu0.h? (lives in src/ atm)
+extern float shAngleRegulate(float);
+extern float shAtan2(float, float);
+extern float shSinF(float);
+extern float shCosF(float);
 
 #endif // VW_MAIN_H

--- a/silent-hill-2/src/view/vw_main.h
+++ b/silent-hill-2/src/view/vw_main.h
@@ -51,10 +51,4 @@ void vwSetViewInfo(void);
 
 void vwSetViewInfoDirectMatrix(VbCOORDINATE* pcoord, sceVu0FMATRIX cammat);
 
-// @todo: should just include sh_vu0.h? (lives in src/ atm)
-extern float shAngleRegulate(float);
-extern float shAtan2(float, float);
-extern float shSinF(float);
-extern float shCosF(float);
-
 #endif // VW_MAIN_H


### PR DESCRIPTION
Some easy vw_main.c matches, had to add a `vu0_unit_matrix` inline for them but not sure if I added in right header or not..

btw is there a way to disable overlay split/build? Usually try to clean build to confirm stuff but overlays make it take a bit longer, if I'm just working on main exe it'd be nice to have a flag to disable them.

(also some reason I was having issues trying to just `make sh2` after making changes too, something about multiply defined ds_sequencer stuff? wish I saved the log... worked fine if I used `make clean && make sh2` to build though, and some reason doesn't seem to happen now if I edit this vw_main.c and try `make sh2`, not really sure what was up with that, maybe just a diff build error I didn't notice 🫠)

If anything needs changes let me know!