### PR TITLE
sh2: match `view/vc_prio.c`, use single index in GET/SET/UNSET_GAME_FLAG, add flag defines

### DIFF
--- a/silent-hill-2/config/SLUS_202.28/SLUS_202.28.yaml
+++ b/silent-hill-2/config/SLUS_202.28/SLUS_202.28.yaml
@@ -348,7 +348,7 @@ segments:
       - [0x192f50, asm, SH2_common/mem_share]
       - [0x1937c0, asm, Effect2/hh_class_flame_03]
       - [0x194300, asm, SH2_common/result]
-      - [0x1951b0, asm, view/vc_prio]
+      - [0x1951b0, c,   view/vc_prio]
       - [0x195480, asm, Effect2/hh_class_blood_05]
       - [0x195cc0, asm, Effect2/hh_class_blood_splash_phenomenon_02]
       - [0x196800, asm, Effect2/hh_class_water_80]

--- a/silent-hill-2/src/Effect2/hh_class_water_10.c
+++ b/silent-hill-2/src/Effect2/hh_class_water_10.c
@@ -384,7 +384,7 @@ u_int HH_Class_Water_10(void* pBlock /* r2 */, ImpactQueue_Element* pElement /* 
             }
             HH_Class_WaterCommon_WaveElement_Time_Count(pThis->Wave_Info, 0x14);
             HH_DBG_Wrapper_T0_COUNT_Delta();
-            if (GET_GAME_FLAG(15, 23)) {
+            if (GET_GAME_FLAG(GAME_FLAG_503)) {
                 pThis->Step = 2;
             }
             pThis->Timer += 1.0f / 30.0f;

--- a/silent-hill-2/src/Effect2/hh_class_water_14.c
+++ b/silent-hill-2/src/Effect2/hh_class_water_14.c
@@ -336,7 +336,7 @@ u_int HH_Class_Water_14(void* pBlock /* r2 */, ImpactQueue_Element* pElement /* 
     switch (pThis->Step) { /* irregular */
         case HH_WATER_14_STEP_INIT:
             Object_Initialize(pThis);
-            if (!GET_GAME_FLAG(15, 22)) {
+            if (!GET_GAME_FLAG(GAME_FLAG_502)) {
                 sceVu0CopyVector(pThis->Location_Defference, (sceVu0FVECTOR){0.0f, 460.0f, 0.0f, 0.0f});
             }
             pThis->Step = 1;
@@ -458,11 +458,11 @@ u_int HH_Class_Water_14(void* pBlock /* r2 */, ImpactQueue_Element* pElement /* 
                 }
             }
             HH_Class_WaterCommon_WaveElement_Time_Count(pThis->Wave_Info, 0x14);
-            if (!GET_GAME_FLAG(15, 22) && GET_GAME_FLAG(15, 21)) {
+            if (!GET_GAME_FLAG(GAME_FLAG_502) && GET_GAME_FLAG(GAME_FLAG_501)) {
                 float add_vec[4] = {0.0f, 15.333334f / time_233, 0.0f, 0.0f}; // r29+0x160
                 sceVu0SubVector(pThis->Location_Defference, pThis->Location_Defference, add_vec);
                 if (pThis->Location_Defference[1] <= 0.0f) {
-                    SET_GAME_FLAG(15, 22);
+                    SET_GAME_FLAG(GAME_FLAG_502);
                 }
             }
             pThis->Timer += 1.0f / 30.0f;

--- a/silent-hill-2/src/Effect2/hh_class_water_30.c
+++ b/silent-hill-2/src/Effect2/hh_class_water_30.c
@@ -328,7 +328,7 @@ u_int HH_Class_Water_30(void* pBlock /* r2 */, ImpactQueue_Element* pElement /* 
 
     switch (pThis->Step) { /* irregular */
         case HH_WATER_30_STEP_INIT:
-            if (GET_GAME_FLAG(4, 20)) {
+            if (GET_GAME_FLAG(GAME_FLAG_148)) {
                 // @bug this is overwritten to 1 below
                 pThis->Step = 2;
             }
@@ -451,15 +451,15 @@ u_int HH_Class_Water_30(void* pBlock /* r2 */, ImpactQueue_Element* pElement /* 
                 }
             }
             HH_Class_WaterCommon_WaveElement_Time_Count(pThis->Wave_Info, 0x14);
-            if (GET_GAME_FLAG(4, 19)) {
+            if (GET_GAME_FLAG(GAME_FLAG_147)) {
                 // @todo: is there a cleaner way to write this float?
                 float add_vec[4] = {0.0f, 50.000004f / time_234, 0.0f, 0.0f};
                 sceVu0AddVector(pThis->Location_Defference, pThis->Location_Defference, add_vec);
                 if (pThis->Location_Defference[1] > 1700.0f) {
-                    SET_GAME_FLAG(4, 20);
+                    SET_GAME_FLAG(GAME_FLAG_148);
                 }
             }
-            if (GET_GAME_FLAG(4, 20)) {
+            if (GET_GAME_FLAG(GAME_FLAG_148)) {
                 pThis->Step = HH_WATER_30_STEP_OFF;
             } else {
                 pThis->Timer += 1.0f / 30.0f;

--- a/silent-hill-2/src/Enemy/en_common.c
+++ b/silent-hill-2/src/Enemy/en_common.c
@@ -146,14 +146,14 @@ int enGetStage(void) {
             ret = 0;
             break;
         case 2:
-            if (GET_GAME_FLAG(7, 27)) {
+            if (GET_GAME_FLAG(GAME_FLAG_251)) {
                 ret = 2;
                 break;
             }
             ret = 1;
             break;
         case 3:
-            if (GET_GAME_FLAG(7, 27)) {
+            if (GET_GAME_FLAG(GAME_FLAG_251)) {
                 ret = 4;
                 break;
             }

--- a/silent-hill-2/src/Event/chizu.c
+++ b/silent-hill-2/src/Event/chizu.c
@@ -150,7 +150,7 @@ void ChizuCurrentPositionCheck(float* px, float* py) {
         case 0x27:                                      /* switch 1 */
         case 0x28:                                      /* switch 1 */
             SET_MAP_POSITION(0.0087f, 0.0096f);
-            if (!(GET_GAME_FLAG(0, 0x19)) && ((GET_GAME_FLAG(0, 0x1A)) == 1)) {
+            if (!(GET_GAME_FLAG(GAME_FLAG_25)) && ((GET_GAME_FLAG(GAME_FLAG_26)) == 1)) {
                 switch (chizu_crnt) {                   /* switch 2; irregular */
                 case 7:                                 /* switch 2 */
                     *px += 24.965286f;
@@ -164,7 +164,7 @@ void ChizuCurrentPositionCheck(float* px, float* py) {
         case 0x25:                                      /* switch 1 */
         case 0x26:                                      /* switch 1 */
             SET_MAP_POSITION(0.00801f, 0.01037f);
-            if (!(GET_GAME_FLAG(0, 0x19)) && ((GET_GAME_FLAG(0, 0x1A)) == 1)) {
+            if (!(GET_GAME_FLAG(GAME_FLAG_25)) && ((GET_GAME_FLAG(GAME_FLAG_26)) == 1)) {
                 switch (chizu_crnt) {                   /* switch 3; irregular */
                 case 7:                                 /* switch 3 */
                     *px += 16.965286f;
@@ -307,34 +307,34 @@ void ChizuCurrentPositionCheck(float* px, float* py) {
             *py = -1956.7996f - (0.019375f * jms->pos.z);
             return;
         case 0x2A:                                      /* switch 1 */
-            if (GET_GAME_FLAG(0, 0x13)) {
+            if (GET_GAME_FLAG(GAME_FLAG_19)) {
                 *px = 1421.101f + (0.01477f * sh2jms.player->pos.x);
                 *py = (0.019658f * -sh2jms.player->pos.z) - 531.00037f;
                 return;
             }
-            if (GET_GAME_FLAG(0, 0x12)) {
+            if (GET_GAME_FLAG(GAME_FLAG_18)) {
                 *px = 1421.101f + (0.01477f * sh2jms.player->pos.x);
                 *py = (0.019658f * -sh2jms.player->pos.z) - 289.90015f;
                 return;
             }
-            if (GET_GAME_FLAG(0, 0x11)) {
+            if (GET_GAME_FLAG(GAME_FLAG_17)) {
                 *px = 1385.2999f + (0.01477f * sh2jms.player->pos.x);
                 *py = (0.019658f * -sh2jms.player->pos.z) - 426.99988f;
                 return;
             }
             break;
         case 0x46:                                      /* switch 1 */
-            if (GET_GAME_FLAG(0, 0x13)) {
+            if (GET_GAME_FLAG(GAME_FLAG_19)) {
                 *px = 240.9f + (0.01477f * sh2jms.player->pos.x);
                 *py = (0.019658f * -sh2jms.player->pos.z) - 6029.8965f;
                 return;
             }
-            if (GET_GAME_FLAG(0, 0x12)) {
+            if (GET_GAME_FLAG(GAME_FLAG_18)) {
                 *px = 238.69986f + (0.01477f * sh2jms.player->pos.x);
                 *py = (0.019658f * -sh2jms.player->pos.z) - 5789.196f;
                 return;
             }
-            if (GET_GAME_FLAG(0, 0x11)) {
+            if (GET_GAME_FLAG(GAME_FLAG_17)) {
                 *px = 203.69986f + (0.01477f * sh2jms.player->pos.x);
                 *py = (0.019658f * -sh2jms.player->pos.z) - 5931.196f;
                 return;

--- a/silent-hill-2/src/Event/event.c
+++ b/silent-hill-2/src/Event/event.c
@@ -175,11 +175,9 @@ static int EventExecFlag(void) {
     st = EventListElement(el, 0xD);
     fl = EventListElement(el, 0x16);
     if (st == 1) {
-        SET_GAME_FLAG(fl >> 5, fl & 0x1F);
-        // SET_FLAG(game_flag.flag, fl); 
+        SET_GAME_FLAG(fl);
     } else {
-        UNSET_GAME_FLAG(fl >> 5, fl & 0x1F);
-        // UNSET_FLAG(game_flag.flag, fl);
+        UNSET_GAME_FLAG(fl);
     }
     EventExecSubFlagSet(el);
     return 1;
@@ -230,8 +228,7 @@ static int EventExecProgram(void) {
         if (ev_prog_flag_set != 0) {
             flg = EventListElement(el, 0x16);
             if (flg != 0) {
-                SET_GAME_FLAG(flg >> 5, flg & 0x1F);
-                //SET_FLAG(game_flag.flag, flg);
+                SET_GAME_FLAG(flg);
             }
         }
         return 1;
@@ -282,7 +279,7 @@ static int EventExecDoor(void) {
         }
         fl = EventListElement(el, 0x16);
         if (fl != 0) {
-            SET_GAME_FLAG(fl >> 5, fl & 0x1F);
+            SET_GAME_FLAG(fl);
         }
         EventExecSubFlagSet(el);
         SCNowPlayableEventSwitch(sh2jms.player, 1);
@@ -312,7 +309,7 @@ int LightSpotOnOffCheck(void) {
     if (!item.light_switch) {
         return 0;
     }
-    if (GET_GAME_FLAG(8, 16)) {
+    if (GET_GAME_FLAG(GAME_FLAG_272)) {
         return 0;
     }
     return 1;

--- a/silent-hill-2/src/Event/event.h
+++ b/silent-hill-2/src/Event/event.h
@@ -5,18 +5,41 @@
 #include "Chacter/character.h"
 #include "Event/item.h"
 
-// Flag bit indexes used with `GET_GAME_FLAG2`
+// Flag bit indexes used with `GET_GAME_FLAG`/`SET_GAME_FLAG`/`UNSET_GAME_FLAG`.
+#define GAME_FLAG_15  15
+#define GAME_FLAG_16  16
+#define GAME_FLAG_17  17
+#define GAME_FLAG_18  18
+#define GAME_FLAG_19  19
+#define GAME_FLAG_25  25
+#define GAME_FLAG_26  26
 #define GAME_FLAG_43  43
 #define GAME_FLAG_47  47
 #define GAME_FLAG_62  62
 #define GAME_FLAG_66  66
 #define GAME_FLAG_67  67
+#define GAME_FLAG_68  68
 #define GAME_FLAG_72  72
 #define GAME_FLAG_88  88
 #define GAME_FLAG_95  95
 #define GAME_FLAG_117 117
 #define GAME_FLAG_146 146
+#define GAME_FLAG_147 147
+#define GAME_FLAG_148 148
 #define GAME_FLAG_168 168
+#define GAME_FLAG_171 171
+#define GAME_FLAG_192 192
+#define GAME_FLAG_193 193
+#define GAME_FLAG_194 194
+#define GAME_FLAG_197 197
+#define GAME_FLAG_227 227
+#define GAME_FLAG_228 228
+#define GAME_FLAG_251 251
+#define GAME_FLAG_272 272
+#define GAME_FLAG_501 501
+#define GAME_FLAG_502 502
+#define GAME_FLAG_503 503
+#define GAME_FLAG_607 607
 
 #define SET_EV_STEP(p_step, s_step) \
 do {                                \
@@ -24,11 +47,9 @@ do {                                \
     ev_s_step = s_step;             \
 } while (0);
 
-#define GET_GAME_FLAG(index, bit) ((game_flag.flag[index] >> (bit)) & 1)
-#define SET_GAME_FLAG(index, bit) ((game_flag.flag[index] |= (1 << (bit))))
-#define UNSET_GAME_FLAG(index, bit) ((game_flag.flag[index] &= ~(1 << (bit))))
-
-#define GET_GAME_FLAG2(index) ((game_flag.flag[(index) / 32] >> ((index) % 32)) & 1)
+#define GET_GAME_FLAG(index) ((game_flag.flag[(index) >> 5] >> ((index) & 0x1F)) & 1)
+#define SET_GAME_FLAG(index) ((game_flag.flag[(index) >> 5] |= (1 << ((index) & 0x1F))))
+#define UNSET_GAME_FLAG(index) ((game_flag.flag[(index) >> 5] &= ~(1 << ((index) & 0x1F))))
 
 // total size: 0x10
 typedef struct Event_List {

--- a/silent-hill-2/src/Event/event.h
+++ b/silent-hill-2/src/Event/event.h
@@ -5,6 +5,19 @@
 #include "Chacter/character.h"
 #include "Event/item.h"
 
+// Flag bit indexes used with `GET_GAME_FLAG2`
+#define GAME_FLAG_43  43
+#define GAME_FLAG_47  47
+#define GAME_FLAG_62  62
+#define GAME_FLAG_66  66
+#define GAME_FLAG_67  67
+#define GAME_FLAG_72  72
+#define GAME_FLAG_88  88
+#define GAME_FLAG_95  95
+#define GAME_FLAG_117 117
+#define GAME_FLAG_146 146
+#define GAME_FLAG_168 168
+
 #define SET_EV_STEP(p_step, s_step) \
 do {                                \
     ev_p_step = p_step;             \
@@ -14,6 +27,8 @@ do {                                \
 #define GET_GAME_FLAG(index, bit) ((game_flag.flag[index] >> (bit)) & 1)
 #define SET_GAME_FLAG(index, bit) ((game_flag.flag[index] |= (1 << (bit))))
 #define UNSET_GAME_FLAG(index, bit) ((game_flag.flag[index] &= ~(1 << (bit))))
+
+#define GET_GAME_FLAG2(index) ((game_flag.flag[(index) / 32] >> ((index) % 32)) & 1)
 
 // total size: 0x10
 typedef struct Event_List {

--- a/silent-hill-2/src/Event/memo.c
+++ b/silent-hill-2/src/Event/memo.c
@@ -214,15 +214,15 @@ static void MemoPictureLoad(union fsFileIndex* file0, union fsFileIndex* file1) 
     switch (select) {
         
         case 17:
-            if (!GET_GAME_FLAG(18, 31)) file0 = file1 = NULL;            
+            if (!GET_GAME_FLAG(GAME_FLAG_607)) file0 = file1 = NULL;            
             break;
         
         case 31:
-            if (!GET_GAME_FLAG(5, 11)) file0 = file1 = NULL;            
+            if (!GET_GAME_FLAG(GAME_FLAG_171)) file0 = file1 = NULL;            
             break;
         
         case 32:    
-            if (!GET_GAME_FLAG(7, 3) && !GET_GAME_FLAG(7, 4))
+            if (!GET_GAME_FLAG(GAME_FLAG_227) && !GET_GAME_FLAG(GAME_FLAG_228))
                 file0 = file1 = NULL;            
             break;
     }
@@ -287,12 +287,12 @@ static void MemoSelectBarDraw(int msg /* r2 */, int y /* r16 */) { // not line m
 static void MemoPictureLayerDraw(int rgb) { // apperently this takes an argument
     switch (select) {
         case 17:
-            if (GET_GAME_FLAG(18, 31)) 
+            if (GET_GAME_FLAG(GAME_FLAG_607)) 
                 MemoPictureLayerDrawSafeLock();
             break;
         case 30: MemoPictureLayerDrawGuruguru(); break;
         case 32:
-            if (GET_GAME_FLAG(7, 3) || GET_GAME_FLAG(7, 4))
+            if (GET_GAME_FLAG(GAME_FLAG_227) || GET_GAME_FLAG(GAME_FLAG_228))
                 
                 MemoPictureLayerDrawAngelRing();            
             break;
@@ -314,7 +314,7 @@ static void MemoPictureLayerDrawAngelRing(void) { // not line matched (need to a
     pic.tex = -1;
     pic.clut = -1;
     pic.status |= 1;
-    if (GET_GAME_FLAG(7, 3)) {
+    if (GET_GAME_FLAG(GAME_FLAG_227)) {
         pic.x0 = 0x939;
         pic.y0 = 0x635;
         pic.x1 = 0xA39;
@@ -335,7 +335,7 @@ static void MemoPictureLayerDrawAngelRing(void) { // not line matched (need to a
         pic.status |= 0x20;
         PictureDraw((struct PicDraw_Data*) &pic);
     }
-    if (GET_GAME_FLAG(7, 4)) {
+    if (GET_GAME_FLAG(GAME_FLAG_228)) {
         pic.x0 = 0x472;
         pic.y0 = 6;
         pic.x1 = 0x572;

--- a/silent-hill-2/src/Event/stage/stg_apart_e3fw.c
+++ b/silent-hill-2/src/Event/stage/stg_apart_e3fw.c
@@ -70,12 +70,12 @@ extern /* static */ CharaData_DemoList stg_apart_e3fw_kagikeri_data[4]; // @ 0x0
             CharaAdminPlayableDisplay(1);
             SCNowDemoEventSwitch(sh2jms.player, false);
             vcReturnPreAutoCamWork(1);
-            SET_GAME_FLAG(2, 3);
+            SET_GAME_FLAG(GAME_FLAG_67);
             EV_PROG_STEP(13);
             /* fallthrough */
 
         case 13:
-            if (GET_GAME_FLAG(2, 2))
+            if (GET_GAME_FLAG(GAME_FLAG_66))
                 stg_apart_e3fw_EvProgSubScreamOn();
 
             SCNowPlayableEventSwitch(sh2jms.player, false);
@@ -88,7 +88,7 @@ extern /* static */ CharaData_DemoList stg_apart_e3fw_kagikeri_data[4]; // @ 0x0
 /* static */ int stg_apart_e3fw_EvProgGetHandgun(void) {
     int ret = EvSubItemGetAndAnim(4, 0); // r16
 
-    if (ret && GET_GAME_FLAG(2, 3)) {
+    if (ret && GET_GAME_FLAG(GAME_FLAG_67)) {
         stg_apart_e3fw_EvProgSubScreamOn();
     }
 
@@ -102,7 +102,7 @@ extern /* static */ CharaData_DemoList stg_apart_e3fw_kagikeri_data[4]; // @ 0x0
 /* static */ void stg_apart_e3fw_EvProgSubScreamOn(void) {
     SubCharacter* scp; // r16
 
-    SET_GAME_FLAG(2, 4);
+    SET_GAME_FLAG(GAME_FLAG_68);
     scp = shCharacter_Manage_GetCharacterList();
 
     while (scp != NULL) {

--- a/silent-hill-2/src/Event/stage/stg_tgs_trial.c
+++ b/silent-hill-2/src/Event/stage/stg_tgs_trial.c
@@ -63,7 +63,7 @@ INCLUDE_ASM("asm/nonmatchings/Event/stage/stg_tgs_trial", EvProgGetNeedle);
     switch (ev_p_step) {
         case 0:
             SCNowPlayableEventSwitch(sh2jms.player, 1);
-            if (GET_GAME_FLAG(6, 0)) EV_PROG_STEP(2);
+            if (GET_GAME_FLAG(GAME_FLAG_192)) EV_PROG_STEP(2);
             else EV_PROG_STEP(10);
             break;
 
@@ -165,7 +165,7 @@ int EvProgLouiseTakecare(void) {
 static int EvProgBoxWithKey(void) {
     switch (ev_p_step) {
         case 0:
-            if (GET_GAME_FLAG(6, 5)) cyl_alp = 0.0f;
+            if (GET_GAME_FLAG(GAME_FLAG_197)) cyl_alp = 0.0f;
             else cyl_alp = 1.0f;
             SCNowPlayableEventSwitch(sh2jms.player, 1);
             ev_cursor_y = 0.0f;
@@ -177,7 +177,7 @@ static int EvProgBoxWithKey(void) {
         
         case 2:
             if (EvSubFileLoadAndFadeOut(NULL, &data_pic_hsp_p_box_tex, &data_pic_hsp_pboxkey01_tex)) {
-                if (GET_GAME_FLAG(6, 2)) {
+                if (GET_GAME_FLAG(GAME_FLAG_194)) {
                     EV_PROG_STEP(9);
                     SeCall(0x4DBA, 1.0f, 0);
                 } else EV_PROG_STEP(10);
@@ -192,8 +192,8 @@ static int EvProgBoxWithKey(void) {
             EvSubPictureEnd();
             
             if (EvSubItemUse0(0x20, 0x17, 0, 0, 0, 0)) {
-                SET_GAME_FLAG(6, 1);
-                if (GET_GAME_FLAG(6, 5)) EV_PROG_STEP(12);
+                SET_GAME_FLAG(GAME_FLAG_68);
+                if (GET_GAME_FLAG(GAME_FLAG_197)) EV_PROG_STEP(12);
                 else EV_PROG_STEP(10);
             }
             break;
@@ -222,7 +222,7 @@ static int EvProgBoxWithKey(void) {
                 (game_flag.guruguru[1] == game_flag.cylinder[1]) &&
                 (game_flag.guruguru[2] == game_flag.cylinder[2]) &&
                 (game_flag.guruguru[3] == game_flag.cylinder[3])) {
-                SET_GAME_FLAG(6, 5);
+                SET_GAME_FLAG(GAME_FLAG_197);
                 SeCall(0x4A46, 1.0f, 0);
                 EV_PROG_STEP(14);
             } else if (shPadTrigger(0, key_config.cancel)) {
@@ -239,7 +239,7 @@ static int EvProgBoxWithKey(void) {
             EvSubPictureEnd();
             cyl_alp -= 0.5f * shGetDT();
             if (cyl_alp <= 0.0f) {
-                if (GET_GAME_FLAG(6, 1)) EV_PROG_STEP(12);
+                if (GET_GAME_FLAG(GAME_FLAG_193)) EV_PROG_STEP(12);
                 else EV_PROG_STEP(16);
             }
             break;
@@ -301,7 +301,7 @@ static int EvProgBoxWithKey(void) {
             EvSubPictureEnd();
             if (EvSubItemGet(0x32, 0x18)) {
                 EV_PROG_STEP(4);
-                SET_GAME_FLAG(5, 11);
+                SET_GAME_FLAG(GAME_FLAG_171);
             }
             break;
         
@@ -309,7 +309,7 @@ static int EvProgBoxWithKey(void) {
             EvSubPictureStart();
             EvSubPictureDisplayOnly();
             
-            if (!GET_GAME_FLAG(5, 11) && !GET_GAME_FLAG(6, 5)) {
+            if (!GET_GAME_FLAG(GAME_FLAG_171) && !GET_GAME_FLAG(GAME_FLAG_197)) {
                 EvProgBoxWithKeyLayer();
             }
             
@@ -321,7 +321,7 @@ static int EvProgBoxWithKey(void) {
     
         case 13:
             SCNowPlayableEventSwitch(sh2jms.player, 0);
-            UNSET_GAME_FLAG(6, 2);
+            UNSET_GAME_FLAG(GAME_FLAG_194);
             return 1;
     }
     return 0;

--- a/silent-hill-2/src/gamemain.c
+++ b/silent-hill-2/src/gamemain.c
@@ -112,7 +112,7 @@ int PlayableMain(void) {
             } else if (!halt) {
                 JumpMenuPosNormal();
                 PlayerSetHeightConnectWait();
-                if (GET_GAME_FLAG(0, 15)) {
+                if (GET_GAME_FLAG(GAME_FLAG_15)) {
                     MariaSetHeightConnectWait();
                 }
                 sh2sys_step_2();

--- a/silent-hill-2/src/view/vc_prio.c
+++ b/silent-hill-2/src/view/vc_prio.c
@@ -1,0 +1,80 @@
+#include "vc_prio.h"
+#include "Event/event.h"
+#include "Event/stg_name.h"
+
+#line 36
+int vcRetPrioStgEvnt(int glb_crd) {
+    int prio_f;
+
+    switch (glb_crd) {
+        case 2:
+            prio_f = vcRetPrioCbEvnt();
+            break;
+        case 9:
+            prio_f = vcRetPrioApEvnt();
+            break;
+        case 3:
+            prio_f = vcRetPrioCcEvnt();
+            break;
+    }
+
+    return prio_f;
+}
+
+#line 63
+int vcRetPrioCbEvnt(void) {
+    int blk_no[4];
+
+    BlockNumber(blk_no, 0, sh2jms.player->pos.x, sh2jms.player->pos.z);
+
+    switch (blk_no[0] & 0xFFFF) {
+        case 54:
+            return GET_GAME_FLAG2(GAME_FLAG_43);
+        case 18:
+            return GET_GAME_FLAG2(GAME_FLAG_47);
+        case 67:
+            return GET_GAME_FLAG2(GAME_FLAG_117);
+    }
+
+    return 0;
+}
+
+#line 86
+int vcRetPrioApEvnt(void) {
+    int room;
+
+    room = RoomNameJms();
+
+    switch (room) {
+        case 23:
+            return GET_GAME_FLAG2(GAME_FLAG_62);
+        case 27:
+            return GET_GAME_FLAG2(GAME_FLAG_66);
+        case 31:
+            return GET_GAME_FLAG2(GAME_FLAG_67);
+        case 24:
+            return GET_GAME_FLAG2(GAME_FLAG_72);
+        case 30:
+            return GET_GAME_FLAG2(GAME_FLAG_88);
+        case 21:
+            return GET_GAME_FLAG2(GAME_FLAG_95);
+        case 33:
+            return GET_GAME_FLAG2(GAME_FLAG_146);
+    }
+
+    return 0;
+}
+
+#line 117
+int vcRetPrioCcEvnt(void) {
+    int blk_no[4];
+
+    BlockNumber(blk_no, 0, sh2jms.player->pos.x, sh2jms.player->pos.z);
+
+    switch (blk_no[0] & 0xFFFF) {
+        case 41:
+            return GET_GAME_FLAG2(GAME_FLAG_168);
+    }
+
+    return 0;
+}

--- a/silent-hill-2/src/view/vc_prio.c
+++ b/silent-hill-2/src/view/vc_prio.c
@@ -29,11 +29,11 @@ int vcRetPrioCbEvnt(void) {
 
     switch (blk_no[0] & 0xFFFF) {
         case 54:
-            return GET_GAME_FLAG2(GAME_FLAG_43);
+            return GET_GAME_FLAG(GAME_FLAG_43);
         case 18:
-            return GET_GAME_FLAG2(GAME_FLAG_47);
+            return GET_GAME_FLAG(GAME_FLAG_47);
         case 67:
-            return GET_GAME_FLAG2(GAME_FLAG_117);
+            return GET_GAME_FLAG(GAME_FLAG_117);
     }
 
     return 0;
@@ -47,19 +47,19 @@ int vcRetPrioApEvnt(void) {
 
     switch (room) {
         case 23:
-            return GET_GAME_FLAG2(GAME_FLAG_62);
+            return GET_GAME_FLAG(GAME_FLAG_62);
         case 27:
-            return GET_GAME_FLAG2(GAME_FLAG_66);
+            return GET_GAME_FLAG(GAME_FLAG_66);
         case 31:
-            return GET_GAME_FLAG2(GAME_FLAG_67);
+            return GET_GAME_FLAG(GAME_FLAG_67);
         case 24:
-            return GET_GAME_FLAG2(GAME_FLAG_72);
+            return GET_GAME_FLAG(GAME_FLAG_72);
         case 30:
-            return GET_GAME_FLAG2(GAME_FLAG_88);
+            return GET_GAME_FLAG(GAME_FLAG_88);
         case 21:
-            return GET_GAME_FLAG2(GAME_FLAG_95);
+            return GET_GAME_FLAG(GAME_FLAG_95);
         case 33:
-            return GET_GAME_FLAG2(GAME_FLAG_146);
+            return GET_GAME_FLAG(GAME_FLAG_146);
     }
 
     return 0;
@@ -73,7 +73,7 @@ int vcRetPrioCcEvnt(void) {
 
     switch (blk_no[0] & 0xFFFF) {
         case 41:
-            return GET_GAME_FLAG2(GAME_FLAG_168);
+            return GET_GAME_FLAG(GAME_FLAG_168);
     }
 
     return 0;

--- a/silent-hill-2/src/view/vc_prio.h
+++ b/silent-hill-2/src/view/vc_prio.h
@@ -1,4 +1,9 @@
 #ifndef VC_PRIO_H
 #define VC_PRIO_H
 
+int vcRetPrioStgEvnt(int glb_crd);
+int vcRetPrioCbEvnt(void);
+int vcRetPrioApEvnt(void);
+int vcRetPrioCcEvnt(void);
+
 #endif // VC_PRIO_H


### PR DESCRIPTION
Updated game flag macros to take single index so we can use a single list of flag defines for them, and added defines for the flags that been seen so far.

Guessing sh2 symbols don't have any enum or anything for these? would have been nice to get proper names for them..