### PR TITLE
sh2: match 6 vc_calc.c, 1 vc_newest.c

### DIFF
--- a/include/vec.h
+++ b/include/vec.h
@@ -111,4 +111,12 @@ static inline void vu0_unit_matrix(sceVu0FMATRIX out) {
         : "+r"(out));
 }
 
+/* Poor mans `pragma fastmath` version of sqrtf. */
+static inline float SQRT(float x) {
+    float result = x;
+    asm("sqrt.s  %0, %0"
+        : "=&f"(result));
+    return result;
+}
+
 #endif // SILENT_VEC_H

--- a/silent-hill-2/config/SLUS_202.28/SLUS_202.28.yaml
+++ b/silent-hill-2/config/SLUS_202.28/SLUS_202.28.yaml
@@ -157,7 +157,7 @@ segments:
       - [0x0a66c0, asm, sh2shd/sh2shd_shadow_vu1_packet]
       - [0x0a6d00, asm, sh2shd/sh2shd_stencil_shadow_main]
       - [0x0a6ed0, asm, sh2shd/sh2shd_structs]
-      - [0x0a6ef0, asm, view/vc_calc]
+      - [0x0a6ef0, c,   view/vc_calc]
       - [0x0a7580, c,   Event/event]
       - [0x0ac650, c,   Event/event_sub]
       - [0x0adf60, c,   Event/item]

--- a/silent-hill-2/src/view/vb_main.h
+++ b/silent-hill-2/src/view/vb_main.h
@@ -77,7 +77,7 @@ void vbSetWorldScreenMatrix(void);
 void vbGetLw(VbCOORDINATE* coord, int fflip);
 int vbSetRefView(VbRVIEW* rview);
 float vbNormalizeRadianAngle(float ang);
-void vbTransposeMatrixWithoutTr(float m0[4], float m1[4]);      // @todo: check types
-void vbApplyMatrixWithoutTr(float* v0, float m0[4], float* v1); // @todo: check types
+void vbTransposeMatrixWithoutTr(float m0[4], float m1[4]); // @todo: check types
+void vbApplyMatrixWithoutTr(sceVu0FVECTOR v0, sceVu0FMATRIX m0, sceVu0FVECTOR v1);
 
 #endif // VB_MAIN_H

--- a/silent-hill-2/src/view/vc_calc.c
+++ b/silent-hill-2/src/view/vc_calc.c
@@ -1,0 +1,136 @@
+#include "vc_calc.h"
+#include "Chacter/m3_play.h"
+#include "SH2_common/sh_vu0.h"
+#include "SH2_common/sh2dt.h"
+#include "view/vb_main.h"
+
+// @note: symbols only had two args, `near_rd_p` is guess
+// @note: weird line numbering?
+#line 30
+float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA* near_rd_p, sceVu0FVECTOR chr_pos, sceVu0FVECTOR cam_tgt_pos) {
+    VC_NEAR_ROAD_DATA cur_near_road;
+    sceVu0FVECTOR ppos;
+    float ofs_ang_y;
+    float near_ratio;
+
+    cur_near_road = *near_rd_p;
+
+    near_ratio = 0.0f;
+    ofs_ang_y = shAngleRegulate(shAtan2(chr_pos[2] - cam_tgt_pos[2], chr_pos[0] - cam_tgt_pos[0]));
+    vcTransRotRoadArea(ppos, cur_near_road.sw_rzm, chr_pos);
+    switch (cur_near_road.rd_dir_type) {
+        case 0:
+            if (TO_RAD(0.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(180.0f)) {
+                near_ratio = (cur_near_road.sw.max_hx - ppos[0]) / (cur_near_road.sw.max_hx - cur_near_road.sw.min_hx);
+            } else {
+                near_ratio = (ppos[0] - cur_near_road.sw.min_hx) / (cur_near_road.sw.max_hx - cur_near_road.sw.min_hx);
+            }
+            break;
+        case 1:
+            if (TO_RAD(-90.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(90.0f)) {
+                near_ratio = (cur_near_road.sw.max_hz - ppos[2]) / (cur_near_road.sw.max_hz - cur_near_road.sw.min_hz);
+            } else {
+                near_ratio = (ppos[2] - cur_near_road.sw.min_hz) / (cur_near_road.sw.max_hz - cur_near_road.sw.min_hz);
+            }
+            break;
+    }
+
+    return near_ratio;
+}
+
+// @note: symbols only showed `chr_pos` param for this.
+// @note: weird line numbering?
+#line 80
+float vcRetNearRatioSwitchAreaForCircleCam(VC_NEAR_ROAD_DATA* near_rd_p, VC_CIR_CAM_MANAGER* cir_man_p, sceVu0FVECTOR chr_pos) {
+    VC_NEAR_ROAD_DATA cur_near_road;
+    VC_CIR_CAM_MANAGER cir_man;
+    sceVu0FVECTOR ppos;
+    float ofs_ang_y;
+    float near_ratio;
+
+    cur_near_road = *near_rd_p;
+    cir_man = *cir_man_p;
+
+    ofs_ang_y = shAngleRegulate(shAtan2(chr_pos[2] - cir_man.origin[2], chr_pos[0] - cir_man.origin[0]));
+    vcTransRotRoadArea(ppos, cur_near_road.sw_rzm, chr_pos);
+
+    if ((TO_RAD(-135.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(-45.0f)) ||
+        (TO_RAD(45.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(135.0f))) {
+        near_ratio = float_abs((cir_man.origin[0] - chr_pos[0]) / cir_man.sw_l[0]);
+    } else {
+        near_ratio = float_abs((cir_man.origin[2] - chr_pos[2]) / cir_man.sw_l[2]);
+    }
+
+    return near_ratio;
+}
+
+#line 127
+void vcTransRotRoadArea(sceVu0FVECTOR v0, sceVu0FMATRIX m, sceVu0FVECTOR v1) {
+    vec_add(v1, m[3], v0);
+    vbApplyMatrixWithoutTr(v0, m, v0);
+
+}
+
+#line 150
+void vcRotTransRoadArea(sceVu0FVECTOR v0, sceVu0FMATRIX m, sceVu0FVECTOR v1) {
+
+    vbApplyMatrixWithoutTr(v0, m, v1);
+    vec_add(v0, m[3], v0);
+}
+
+#line 162
+float vcGetMinInRoadDist(void) {
+    return (BgIsOut(0) != 0) ? 500.0f : 400.0f;
+}
+
+// @note line numbers are close but has mismatch in the if blocks.
+#line 175
+void vcConvertCamFile(VC_ROAD_DATA* road_ary) {
+    VC_ROAD_DATA* rd_p;
+
+    rd_p = road_ary;
+    while (!(rd_p->flags & 1)) {
+
+        rd_p->kind_id <<= 0x10;
+        rd_p->kind_id >>= 0x10;
+
+
+        if (rd_p->ofs_watch_hy == 10000.0f) {
+            rd_p->ofs_watch_hy = -300.0f;
+        } else if (rd_p->ofs_watch_hy == 10001.0f) {
+            rd_p->ofs_watch_hy = -375.0f;
+        } else if (rd_p->ofs_watch_hy == 10002.0f) {
+            rd_p->ofs_watch_hy = -600.0f;
+        }
+
+        if (!rd_p->projection) {
+            rd_p->projection = 448.0f;
+        } else if (rd_p->projection == 10001.0f) {
+            rd_p->projection = 384.0f;
+        }
+
+        if (rd_p->trace_btm_hy == 10000.0f) {
+            rd_p->trace_btm_hy = -300.0f;
+        } else if (rd_p->trace_btm_hy == 10001.0f) {
+            rd_p->trace_btm_hy = -150.0f;
+        } else if (rd_p->trace_btm_hy == 10002.0f) {
+            rd_p->trace_btm_hy = 150.0f;
+        }
+        switch (rd_p->cam_mv_type) {
+            case 0:
+                if (rd_p->tmp.chs.ofs_hy == 10000.0f) {
+                    rd_p->tmp.chs.ofs_hy = -500.0f;
+                }
+                if (rd_p->tmp.chs.ofs_hy == 10001.0f) {
+                    rd_p->tmp.chs.ofs_hy = -125.0f;
+                }
+                break;
+            case 2:
+                if (rd_p->tmp.chs.ofs_hy == 10000.0f) {
+                    rd_p->tmp.chs.ofs_hy = -0.5235988f;
+                }
+                break;
+        }
+        rd_p++;
+    }
+}

--- a/silent-hill-2/src/view/vc_calc.c
+++ b/silent-hill-2/src/view/vc_calc.c
@@ -4,16 +4,12 @@
 #include "SH2_common/sh2dt.h"
 #include "view/vb_main.h"
 
-// @note: symbols only had two args, `near_rd_p` is guess
 // @note: weird line numbering?
 #line 30
-float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA* near_rd_p, sceVu0FVECTOR chr_pos, sceVu0FVECTOR cam_tgt_pos) {
-    VC_NEAR_ROAD_DATA cur_near_road;
+float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA cur_near_road, sceVu0FVECTOR chr_pos, sceVu0FVECTOR cam_tgt_pos) {
     sceVu0FVECTOR ppos;
     float ofs_ang_y;
     float near_ratio;
-
-    cur_near_road = *near_rd_p;
 
     near_ratio = 0.0f;
     ofs_ang_y = shAngleRegulate(shAtan2(chr_pos[2] - cam_tgt_pos[2], chr_pos[0] - cam_tgt_pos[0]));
@@ -38,18 +34,12 @@ float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA* near_rd_p, sceVu0FVECTO
     return near_ratio;
 }
 
-// @note: symbols only showed `chr_pos` param for this.
 // @note: weird line numbering?
 #line 80
-float vcRetNearRatioSwitchAreaForCircleCam(VC_NEAR_ROAD_DATA* near_rd_p, VC_CIR_CAM_MANAGER* cir_man_p, sceVu0FVECTOR chr_pos) {
-    VC_NEAR_ROAD_DATA cur_near_road;
-    VC_CIR_CAM_MANAGER cir_man;
+float vcRetNearRatioSwitchAreaForCircleCam(VC_NEAR_ROAD_DATA cur_near_road, VC_CIR_CAM_MANAGER cir_man, sceVu0FVECTOR chr_pos) {
     sceVu0FVECTOR ppos;
     float ofs_ang_y;
     float near_ratio;
-
-    cur_near_road = *near_rd_p;
-    cir_man = *cir_man_p;
 
     ofs_ang_y = shAngleRegulate(shAtan2(chr_pos[2] - cir_man.origin[2], chr_pos[0] - cir_man.origin[0]));
     vcTransRotRoadArea(ppos, cur_near_road.sw_rzm, chr_pos);

--- a/silent-hill-2/src/view/vc_calc.c
+++ b/silent-hill-2/src/view/vc_calc.c
@@ -4,29 +4,40 @@
 #include "SH2_common/sh2dt.h"
 #include "view/vb_main.h"
 
-// @note: weird line numbering?
 #line 30
 float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA cur_near_road, sceVu0FVECTOR chr_pos, sceVu0FVECTOR cam_tgt_pos) {
-    sceVu0FVECTOR ppos;
+    float near_ratio = 0.0f;
     float ofs_ang_y;
-    float near_ratio;
+    sceVu0FVECTOR ppos;
 
-    near_ratio = 0.0f;
     ofs_ang_y = shAngleRegulate(shAtan2(chr_pos[2] - cam_tgt_pos[2], chr_pos[0] - cam_tgt_pos[0]));
+
+
+
+
     vcTransRotRoadArea(ppos, cur_near_road.sw_rzm, chr_pos);
+
     switch (cur_near_road.rd_dir_type) {
         case 0:
             if (TO_RAD(0.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(180.0f)) {
                 near_ratio = (cur_near_road.sw.max_hx - ppos[0]) / (cur_near_road.sw.max_hx - cur_near_road.sw.min_hx);
+
+
             } else {
                 near_ratio = (ppos[0] - cur_near_road.sw.min_hx) / (cur_near_road.sw.max_hx - cur_near_road.sw.min_hx);
+
+
             }
             break;
         case 1:
             if (TO_RAD(-90.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(90.0f)) {
                 near_ratio = (cur_near_road.sw.max_hz - ppos[2]) / (cur_near_road.sw.max_hz - cur_near_road.sw.min_hz);
+
+
             } else {
                 near_ratio = (ppos[2] - cur_near_road.sw.min_hz) / (cur_near_road.sw.max_hz - cur_near_road.sw.min_hz);
+
+
             }
             break;
     }
@@ -37,9 +48,9 @@ float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA cur_near_road, sceVu0FVE
 // @note: weird line numbering?
 #line 80
 float vcRetNearRatioSwitchAreaForCircleCam(VC_NEAR_ROAD_DATA cur_near_road, VC_CIR_CAM_MANAGER cir_man, sceVu0FVECTOR chr_pos) {
-    sceVu0FVECTOR ppos;
-    float ofs_ang_y;
     float near_ratio;
+    float ofs_ang_y;
+    sceVu0FVECTOR ppos;
 
     ofs_ang_y = shAngleRegulate(shAtan2(chr_pos[2] - cir_man.origin[2], chr_pos[0] - cir_man.origin[0]));
     vcTransRotRoadArea(ppos, cur_near_road.sw_rzm, chr_pos);

--- a/silent-hill-2/src/view/vc_calc.c
+++ b/silent-hill-2/src/view/vc_calc.c
@@ -53,14 +53,27 @@ float vcRetNearRatioSwitchAreaForCircleCam(VC_NEAR_ROAD_DATA cur_near_road, VC_C
     sceVu0FVECTOR ppos;
 
     ofs_ang_y = shAngleRegulate(shAtan2(chr_pos[2] - cir_man.origin[2], chr_pos[0] - cir_man.origin[0]));
+
+
+
+
+
+
+
     vcTransRotRoadArea(ppos, cur_near_road.sw_rzm, chr_pos);
 
     if ((TO_RAD(-135.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(-45.0f)) ||
         (TO_RAD(45.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(135.0f))) {
+
+
         near_ratio = float_abs((cir_man.origin[0] - chr_pos[0]) / cir_man.sw_l[0]);
+
     } else {
         near_ratio = float_abs((cir_man.origin[2] - chr_pos[2]) / cir_man.sw_l[2]);
+
     }
+
+
 
     return near_ratio;
 }

--- a/silent-hill-2/src/view/vc_calc.c
+++ b/silent-hill-2/src/view/vc_calc.c
@@ -18,7 +18,7 @@ float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA cur_near_road, sceVu0FVE
     vcTransRotRoadArea(ppos, cur_near_road.sw_rzm, chr_pos);
 
     switch (cur_near_road.rd_dir_type) {
-        case 0:
+        case VC_RD_DIR_Z: // @note: Enum name might be switched with `VC_RD_DIR_X` (these names came from outside SH2 symbols)
             if (TO_RAD(0.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(180.0f)) {
                 near_ratio = (cur_near_road.sw.max_hx - ppos[0]) / (cur_near_road.sw.max_hx - cur_near_road.sw.min_hx);
 
@@ -29,7 +29,7 @@ float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA cur_near_road, sceVu0FVE
 
             }
             break;
-        case 1:
+        case VC_RD_DIR_X: // @note: Enum name might be switched with `VC_RD_DIR_Z`
             if (TO_RAD(-90.0f) <= ofs_ang_y && ofs_ang_y < TO_RAD(90.0f)) {
                 near_ratio = (cur_near_road.sw.max_hz - ppos[2]) / (cur_near_road.sw.max_hz - cur_near_road.sw.min_hz);
 
@@ -103,7 +103,7 @@ void vcConvertCamFile(VC_ROAD_DATA* road_ary) {
     VC_ROAD_DATA* rd_p;
 
     rd_p = road_ary;
-    while (!(rd_p->flags & 1)) {
+    while (!(rd_p->flags & VC_RD_END_DATA_F)) {
 
         rd_p->kind_id <<= 0x10;
         rd_p->kind_id >>= 0x10;

--- a/silent-hill-2/src/view/vc_calc.h
+++ b/silent-hill-2/src/view/vc_calc.h
@@ -4,8 +4,8 @@
 #include "view/vc_main.h"
 
 // @todo: check float*/float[] types
-float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA* near_rd_p, sceVu0FVECTOR chr_pos, sceVu0FVECTOR cam_tgt_pos);
-float vcRetNearRatioSwitchAreaForCircleCam(VC_NEAR_ROAD_DATA* near_rd_p, VC_CIR_CAM_MANAGER* cir_man_p, sceVu0FVECTOR chr_pos);
+float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA cur_near_road, sceVu0FVECTOR chr_pos, sceVu0FVECTOR cam_tgt_pos);
+float vcRetNearRatioSwitchAreaForCircleCam(VC_NEAR_ROAD_DATA cur_near_road, VC_CIR_CAM_MANAGER cir_man, sceVu0FVECTOR chr_pos);
 void vcTransRotRoadArea(sceVu0FVECTOR v0, sceVu0FMATRIX m, sceVu0FVECTOR v1);
 void vcRotTransRoadArea(sceVu0FVECTOR v0, sceVu0FMATRIX m, sceVu0FVECTOR v1);
 float vcGetMinInRoadDist(void);

--- a/silent-hill-2/src/view/vc_calc.h
+++ b/silent-hill-2/src/view/vc_calc.h
@@ -4,10 +4,10 @@
 #include "view/vc_main.h"
 
 // @todo: check float*/float[] types
-float vcRetNearRatioSwitchAreaInXZPos(float* chr_pos, float* cam_tgt_pos);
-float vcRetNearRatioSwitchAreaForCircleCam(float* chr_pos);
-void vcTransRotRoadArea(float* v0, float m[4], float* v1);
-void vcRotTransRoadArea(float* v0, float m[4], float* v1);
+float vcRetNearRatioSwitchAreaInXZPos(VC_NEAR_ROAD_DATA* near_rd_p, sceVu0FVECTOR chr_pos, sceVu0FVECTOR cam_tgt_pos);
+float vcRetNearRatioSwitchAreaForCircleCam(VC_NEAR_ROAD_DATA* near_rd_p, VC_CIR_CAM_MANAGER* cir_man_p, sceVu0FVECTOR chr_pos);
+void vcTransRotRoadArea(sceVu0FVECTOR v0, sceVu0FMATRIX m, sceVu0FVECTOR v1);
+void vcRotTransRoadArea(sceVu0FVECTOR v0, sceVu0FMATRIX m, sceVu0FVECTOR v1);
 float vcGetMinInRoadDist(void);
 void vcConvertCamFile(VC_ROAD_DATA* road_ary);
 

--- a/silent-hill-2/src/view/vc_main.h
+++ b/silent-hill-2/src/view/vc_main.h
@@ -174,7 +174,7 @@ typedef struct _VC_ROAD_DATA {
     /* 0x20 */ VC_ROAD_AREA lim_rd;
     /* 0x40 */ int kind_id;
     /* 0x44 */ int flags; // `VC_ROAD_FLAGS`
-    /* 0x48 */ VC_AREA_SIZE_TYPE area_size_type;
+    /* 0x48 */ int area_size_type; // `VC_AREA_SIZE_TYPE`
     /* 0x4c */ int rd_type;
     /* 0x50 */ VC_CAM_MV_TYPE mv_y_type; // Unsure if correct type, `cam_mv_type` likely uses this enum too, maybe both use it for diff reasons?
     /* 0x54 */ float ofs_watch_hy;

--- a/silent-hill-2/src/view/vc_newest.c
+++ b/silent-hill-2/src/view/vc_newest.c
@@ -107,11 +107,51 @@ void vcWarpForFixAngCam(VC_WORK* v_p) {
     }
 }
 
-INCLUDE_ASM("asm/nonmatchings/view/vc_newest", vcRetCirRadiusReduction);
+// @todo: Likely a static in vcRetCirRadiusReduction (vc_main.c also seems to have a separate `far_tgt_watch_cir_r_0x003905C0` var.)
+extern float far_tgt_watch_cir_r_0x00399F40[];
+
+#line 210
+float vcRetCirRadiusReduction(VC_WORK* w_p) {
+    float real_r;
+    float deflt_r;
+    float cam2chr_xz_dist;
+    float ofs_ang_y;
+    float x;
+    float z;
+    float rate;
+    cam2chr_xz_dist = vec3_dist_xz(w_p->chara_pos, w_p->cam_pos);
+    cam2chr_xz_dist /= 2.0f;
+    ofs_ang_y = shAtan2(w_p->chara_pos[2] - w_p->cam_pos[2],
+                        w_p->chara_pos[0] - w_p->cam_pos[0]);
+
+
+
+    deflt_r = far_tgt_watch_cir_r_0x00399F40[w_p->cur_near_road.road_p->area_size_type];
+
+
+
+    z = cam2chr_xz_dist * shSinF(ofs_ang_y) + deflt_r * shSinF(w_p->chara_eye_ang_y);
+
+
+    x = cam2chr_xz_dist * shCosF(ofs_ang_y) + deflt_r * shCosF(w_p->chara_eye_ang_y);
+
+
+
+    real_r = SQRT(z * z + x * x);
+
+    rate = float_abs(shAngleRegulate(w_p->chara_eye_ang_y - ofs_ang_y) / PI);
+
+
+
+
+    rate = 1.0f - rate;
+
+    return real_r * rate;
+}
 
 #line 255
 void vcChangeProjByDist(VC_NEAR_ROAD_DATA* near_rd_p, float mv_vec_y) {
-    if (near_rd_p->road_p->area_size_type == VC_AREA_OUTDOOR &&
+    if ((VC_AREA_SIZE_TYPE)near_rd_p->road_p->area_size_type == VC_AREA_OUTDOOR &&
         (near_rd_p->road_p->mv_y_type == VC_MV_LOCUS_CIRCLE || near_rd_p->road_p->mv_y_type == VC_MV_THROUGH_DOOR)) {
 
 


### PR DESCRIPTION
Couple funcs here were missing params in the symbols, but the params were getting used in the func - also noticed while making the PR these are all pointers that got immediately copied to locals too, looks like it might mean they're passed-by-value instead of being pointers in the prototype?

Seems to still match when I switch them to that, not sure if this was already known but something to look for when func syms are missing params.

(this value-copying seems to mess with line numbering though, both funcs that do it get random high line numbers added, was able to mostly match line numbers in https://decomp.me/scratch/7XDnZ but not sure why https://decomp.me/scratch/jnI1e is so broken)

Also was able to match last func in vc_newest with the new vec3_dist_xz inline 😸