### PR TITLE
sh3: Minor main loop recognition work

### DIFF
--- a/silent-hill-3/config/SLUS_206.22/symbol_addrs.txt
+++ b/silent-hill-3/config/SLUS_206.22/symbol_addrs.txt
@@ -1,5 +1,8 @@
 entry = 0x0100008;
 
+// gamemain.c
+GameMain = 0x194480;
+
 // main.c
 main = 0x12ca70;
 db_watch_point = 0x3d44b0;

--- a/silent-hill-3/src/main.c
+++ b/silent-hill-3/src/main.c
@@ -49,7 +49,7 @@ int main(int argc, s_char* argv[]) {
             func_001D9090(1);
             *T0_COUNT = 0;
             func_001E5170();
-            func_00194480();
+            GameMain();
             func_0012DCB0(2);
             func_0012DCB0(0);
             func_001D90D0();

--- a/silent-hill-3/src/main.h
+++ b/silent-hill-3/src/main.h
@@ -71,8 +71,11 @@ extern void func_00172FA0(void);
  * 14 = Option menu
  *
  * @note PC apparently shares the same list.
+ *
+ * @note SH2 counterpart and PC in Ghidra tells this function returns some 4 byte value.
  */
 extern void GameMain(void);
+
 extern void func_00195490(void);
 extern void func_00195A40(void);
 extern void func_00195B90(void);
@@ -89,7 +92,13 @@ extern void func_00337AB0(void);
 
 extern int func_00115890(int arg0);
 extern void func_0012BDF0(s_char* arg0);
+
+/* @brief This function set a value to the equivalent of `_SH2_SYS::step[]`.
+ * Just like `func_0012D080` but it instead of retrieving the value it sets
+ * the value.
+ */
 extern void func_0012CFE0(int arg0);
+
 extern void func_0012DCB0(int arg0);
 extern void shSetDF(int fpi);
 extern void func_0019B450(void);
@@ -101,6 +110,25 @@ extern void func_001E4E30(int arg0);
 extern void func_00281D80(int, int);
 extern void func_00282090(int arg0);
 
+/* extern void func_0026730(int arg0);
+ * Used to defines values related framerate limit and sets game's delta timer value.
+ */
+ 
+/* extern int func_002A6340(void);
+ * Handle both splash screen and main title screen.
+ * Unlike SH1/2 where the splash screen is handled in a different state, SH3 handles
+ * the splash screen in the same state as the main title screen.
+ *
+ * 3 = Warning Content Screen Start
+ * 4 = Unused Warning Unfinished State Screen
+ */
+
+/* extern void func_002A6730(int arg0, int arg1);
+ * Used during the splash screens.
+ * @param arg0 Background image index
+ * @param arg1 Text index
+ */
+ 
 extern int D_003D44A0;
 extern int D_003D44A8;
 extern int D_003D44B0;

--- a/silent-hill-3/src/main.h
+++ b/silent-hill-3/src/main.h
@@ -38,9 +38,16 @@ extern void func_0012C980(void);
 extern int func_0012C9B0(void);
 extern void func_0012CED0(void);
 extern void func_0012CEF0(void);
+
+/* @brief This function retrieves the equivalent of `_SH2_SYS::step[]`.
+ * While in SH2 it is required to manually input what state to retrieve, SH3
+ * handle this with this function which returns the state of the game based
+ * on the current level the code is being executed.
+ */
 extern int func_0012D080(void);
+
 extern void func_0012DC50(void);
-extern void func_0012DCA0(void);
+extern void func_0012DCA0(void); 
 extern void func_00130640(int arg0);
 extern int func_00130650(void);
 extern void func_0013A780(void);
@@ -55,7 +62,17 @@ extern int func_00156B50(int arg0);
 extern int func_00156B80(int arg1);
 extern void func_0015DB70(void);
 extern void func_00172FA0(void);
-extern void func_00194480(void);
+
+/* @note Game states.
+ * 1  = Main menu/splash screen
+ * 2  = Loading screen
+ * 5  = In-game
+ * 6  = Inventory
+ * 14 = Option menu
+ *
+ * @note PC apparently shares the same list.
+ */
+extern void GameMain(void);
 extern void func_00195490(void);
 extern void func_00195A40(void);
 extern void func_00195B90(void);


### PR DESCRIPTION
Made some notes in some of the splash screen functions and also recognized `GameMain`.


An additional thing I did was doing a little bit of documentation on how the game handle game states as it actually differ a little from what can be seen in SH1/2.

For the little I have seen from SH2 code it's not much the difference with SH1, however, they did modified it in 3. It may look complex at first glance, but in reality it's simple.

While in SH1/2 you have to specify the state you are using, in SH3 you have a function that returns a specific index of the game state which you need to update based on the level of the code and the intentions.

For example if in SH2 (also kinda in SH1) we have:
```c
switch (Sh2sys.step[1]) {
    ...
    case Main_TitleScreen:
        ...
        switch (Sh2sys.step[2]) {
            case TitleScreen_NewGame:
            ...
```

In 3 it would be handled like this
```c

switch (func_0012D080()) {  // <- Currently returning `Sh3sys.step[1]`
    ...
    case Main_TitleScreen:
        ...
        FUN_0012cfa0(0); // <- By default it will always sum 1 to the variable used to access to `Sh3sys.step[]`
        switch (func_0012D080()) { // <- Currently returning `Sh3sys.step[2]`
            case TitleScreen_NewGame:
            ...

```

There is also another function (`func_0012CFE0`) which let you change the value of the currently active `Sh3sys.step` level, so following the previous example if the player have selected the "load" option, but suddenly takes off the memory card, thus making the option unavailable, it will cause `Sh3sys.step[2]` to switch to another available option and so the code will use `func_0012CFE0` to update `Sh3sys.step[2]`.

I don't know how the system fully works, so I can't tell how it will handle clear cases the game is using multiple sub-states, but this gives you an idea of how SH3 handles game states compared to SH1/2.

Also my this is my first contribution :D!