### PR TITLE
alessatool: objdiff workflow improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - ci/test
+      - alessatool/merge/dependencies
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - ci/test
-      - alessatool/merge/dependencies
     paths-ignore:
       - '**.md'
 

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,9 @@ OBJDIFF_BINARY := objdiff-cli-$(PLATFORM)-$(ARCH)
 OBJDIFF := $(TOOLS)/$(OBJDIFF_BINARY)
 OBJDIFF_CONFIG := objdiff.json
 OBJDIFF_FRAGMENTS = $(patsubst $(CONFIG)/%.yaml, $(BUILD)/objdiff/%.json, $(YAMLS))
-CREATE_OBJDIFF_CONFIG = $(ALESSATOOL) merge objdiff --categories-path $(CONFIG)/categories.json
+CREATE_OBJDIFF_CONFIG = $(ALESSATOOL) merge objdiff \
+	--categories-path $(CONFIG)/categories.json \
+	--project $(PROJECT)
 
 ALESSATOOL := $(PYTHON) $(TOOLS)/alessatool/alessatool.py --verbose
 ALESSATOOL_OVERLAY_LOCK := $(OVERLAY_SOURCE_DIR)/.lock
@@ -156,13 +158,13 @@ ifeq ($(GENERATE_REPORT),0)
 	GENERATE_FLAGS += --no-objdiff
 	GENERATE_OVERLAY_FLAGS += --no-objdiff
 else
-	GENERATE_FLAGS += --objdiff-output-path=$(BUILD)/objdiff/$*.json
-	GENERATE_OVERLAY_FLAGS += --objdiff-output-path=$(BUILD)/objdiff/overlay/$*.json
+	GENERATE_FLAGS += --objdiff-output-path=$(BUILD)/objdiff/$*.json --no-dependencies
+	GENERATE_OVERLAY_FLAGS += --objdiff-output-path=$(BUILD)/objdiff/overlay/$*.json --no-dependencies
 endif
 ifeq ($(GENERATE_LCF),0)
 	GENERATE_FLAGS += --no-lcf
 endif
-GENERATE_EXPECTED := $(GENERATE) --no-lcf --no-dependencies --make-full-disasm-for-code
+GENERATE_EXPECTED := $(GENERATE) --no-lcf --make-full-disasm-for-code
 
 CHECK_MATCH_PERCENT :=
 ifneq ($(NON_MATCHING),1)
@@ -285,6 +287,7 @@ $(LINKER_SCRIPT): $(SPLAT_CONFIG) $(CONFIG)/$(SERIAL).yaml $(LINKER_TEMPLATE)
 
 $(OBJDIFF_CONFIG): $(OBJDIFF_FRAGMENTS)
 	$(CREATE_OBJDIFF_CONFIG) $^
+	$(ALESSATOOL) $(MERGE_DEPENDENCIES)
 
 $(BUILD)/objdiff/%.json: $(CONFIG)/%.yaml
 	$(GENERATE_EXPECTED) --objdiff-output-path=$(BUILD)/objdiff/$*.json --make-full-disasm-for-code $(SPLAT_CONFIG) $<

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ LD :=
 ifneq ($(NON_MATCHING),1)
 ifneq ($(LINK),0)
 	LD = $(WIBO) $(MWLD) -o "$@" $(MWLD_FLAGS) \
-			"$(LINKER_SCRIPT)" $(shell find $(BUILD) -name "*.o")
+			"$(LINKER_SCRIPT)" $(filter %.o, $^)
 endif
 endif
 
@@ -134,6 +134,7 @@ OBJDIFF_BINARY := objdiff-cli-$(PLATFORM)-$(ARCH)
 OBJDIFF := $(TOOLS)/$(OBJDIFF_BINARY)
 OBJDIFF_CONFIG := objdiff.json
 OBJDIFF_FRAGMENTS = $(patsubst $(CONFIG)/%.yaml, $(BUILD)/objdiff/%.json, $(YAMLS))
+CREATE_OBJDIFF_CONFIG = $(ALESSATOOL) merge objdiff --categories-path $(CONFIG)/categories.json
 
 ALESSATOOL := $(PYTHON) $(TOOLS)/alessatool/alessatool.py --verbose
 ALESSATOOL_OVERLAY_LOCK := $(OVERLAY_SOURCE_DIR)/.lock
@@ -147,6 +148,7 @@ EXTRACT := extract \
 	--archive-path $(SOURCE_OVERLAY_ARCHIVE) \
 	--output-dir $(ROM) \
 	--overlay
+MERGE_DEPENDENCIES = merge dependencies --d-path $(LINKERS)/$(SERIAL).d
 
 GENERATE_FLAGS = --make-full-disasm-for-code
 GENERATE_OVERLAY_FLAGS = --no-lcf --make-full-disasm-for-code
@@ -160,7 +162,7 @@ endif
 ifeq ($(GENERATE_LCF),0)
 	GENERATE_FLAGS += --no-lcf
 endif
-GENERATE_EXPECTED := $(GENERATE) --no-lcf --make-full-disasm-for-code
+GENERATE_EXPECTED := $(GENERATE) --no-lcf --no-dependencies --make-full-disasm-for-code
 
 CHECK_MATCH_PERCENT :=
 ifneq ($(NON_MATCHING),1)
@@ -264,6 +266,7 @@ $(LINKERS)/%.d: $(CONFIG)/overlay/%.yaml $(OVERLAY_SPLAT_FILES) $(SETUP)
 
 $(LINKERS)/%.d: $(CONFIG)/%.yaml $(SPLAT_FILES) $(SETUP)
 	$(GENERATE) $(GENERATE_FLAGS) $(SPLAT_CONFIG) $<
+	$(ALESSATOOL) $(MERGE_DEPENDENCIES)
 
 $(BUILD)/$(SERIAL): $(SETUP) $(OVERLAY_TARGETS) $(LINKER_SCRIPT)
 	$(LD)

--- a/silent-hill-2/Makefile
+++ b/silent-hill-2/Makefile
@@ -35,4 +35,3 @@ MWLD_FLAGS := \
 	-noinhibit-exec $(MWLD_OVERLAY_FLAGS)
 
 BSS_ALIGNMENT := 8
-

--- a/silent-hill-2/Makefile
+++ b/silent-hill-2/Makefile
@@ -36,4 +36,3 @@ MWLD_FLAGS := \
 
 BSS_ALIGNMENT := 8
 
-CREATE_OBJDIFF_CONFIG = $(ALESSATOOL) merge --categories-path $(CONFIG)/categories.json

--- a/silent-hill-3/Makefile
+++ b/silent-hill-3/Makefile
@@ -65,5 +65,3 @@ MWLD_FLAGS := \
 	-noinhibit-exec $(MWLD_OVERLAY_FLAGS)
 
 BSS_ALIGNMENT := 16
-
-CREATE_OBJDIFF_CONFIG = $(ALESSATOOL) merge --categories-path $(CONFIG)/categories.json

--- a/silent-hill-3/config/SLUS_206.22/overlay/town_00.yaml
+++ b/silent-hill-3/config/SLUS_206.22/overlay/town_00.yaml
@@ -27,5 +27,5 @@ segments:
     subsegments:
       - [0x80, c, Event/stage/town_00]
       - [0x480, data, town_00_data]
-      - { vram: 0x1F6E000, type: .bss, name: town_00_bss }
+      - { vram: 0x1F6E000, type: .bss, name: Event/stage/town_00 }
   - [0xA00]

--- a/silent-hill-3/src/Event/stage/town_00.c
+++ b/silent-hill-3/src/Event/stage/town_00.c
@@ -1,5 +1,7 @@
 #include "town_00.h"
 
+Town00Struct state_town_00; // 0x01F6E000
+
 int func_01F6D680_town_00() {
     int var_s0  = 0;
 

--- a/silent-hill-3/src/Event/stage/town_00.h
+++ b/silent-hill-3/src/Event/stage/town_00.h
@@ -18,8 +18,6 @@ void func_01F6D9D0_town_00(void);
 void func_01F6D9F0_town_00(void);
 void func_01F6DA00_town_00(void);
 
-Town00Struct state_town_00; // 0x01F6E000
-
 extern void PlayerEventMove(float*);
 extern int func_0016C1C0(int);
 extern int func_00190690(void);

--- a/tools/alessatool/alessatool.py
+++ b/tools/alessatool/alessatool.py
@@ -6,7 +6,7 @@ from commands.generate import GenerationArgs, split_yaml
 from commands.extract import ExtractionArgs, extract_mfa
 from commands.annotate import AnnotationArgs, annotate_asm
 from commands.patch import PatchArgs, patch_relocations
-from commands.merge import MergeArgs, merge_objdiff_units
+from commands.merge import MergeArgs, merge_fragments
 from commands.create import CreationArgs, create_overlay_yamls
 
 from commands.util import configure_util_parser
@@ -24,7 +24,7 @@ def patch(args: PatchArgs):
     patch_relocations(args)
 
 def merge(args: MergeArgs):
-    merge_objdiff_units(args)
+    merge_fragments(args)
 
 def create(args: CreationArgs):
     create_overlay_yamls(args)
@@ -107,6 +107,11 @@ def main():
         "--no-lcf",
         action="store_true",
         help="don't generate a linker command file."
+    )
+    generate_parser.add_argument(
+        "--no-dependencies",
+        action="store_true",
+        help="don't generate linker dependencies."
     )
     generate_parser.add_argument(
         "--no-objdiff",
@@ -235,21 +240,30 @@ def main():
         "merge",
         help="merge objdiff.json fragments"
     )
-    merge_parser.add_argument(
-        "--output-path",
+    merge_subparsers = merge_parser.add_subparsers(dest="mode")
+    objdiff_merge_parser = merge_subparsers.add_parser(name="objdiff")
+    objdiff_merge_parser.add_argument(
+        "--objdiff-output-path",
         type=Path,
         default="objdiff.json"
     )
-    merge_parser.add_argument(
+    objdiff_merge_parser.add_argument(
         "--categories-path",
         type=Path,
         default=None
     )
-    merge_parser.add_argument(
+    objdiff_merge_parser.add_argument(
         "objdiff_fragments",
         type=Path,
         nargs="+",
         help="list of json files to merge"
+    )
+    dependencies_merge_parser = merge_subparsers.add_parser(name="dependencies")
+    dependencies_merge_parser.add_argument(
+        "--d-path",
+        type=Path,
+        required=True,
+        help=f"output .d filepath (should be sibling with {INTERMEDIATE_D_NAME})"
     )
     merge_parser.set_defaults(func=merge)
 

--- a/tools/alessatool/alessatool.py
+++ b/tools/alessatool/alessatool.py
@@ -238,7 +238,7 @@ def main():
 
     merge_parser = subparsers.add_parser(
         "merge",
-        help="merge objdiff.json fragments"
+        help="merge `.d` or objdiff.json fragments"
     )
     merge_subparsers = merge_parser.add_subparsers(dest="mode")
     objdiff_merge_parser = merge_subparsers.add_parser(name="objdiff")

--- a/tools/alessatool/alessatool.py
+++ b/tools/alessatool/alessatool.py
@@ -253,6 +253,11 @@ def main():
         default=None
     )
     objdiff_merge_parser.add_argument(
+        "--project",
+        type=str,
+        required=True
+    )
+    objdiff_merge_parser.add_argument(
         "objdiff_fragments",
         type=Path,
         nargs="+",

--- a/tools/alessatool/commands/generate.py
+++ b/tools/alessatool/commands/generate.py
@@ -130,9 +130,6 @@ def generate_linker_dependencies(args: GenerationArgs):
     ensure_path_and_write(output_path, output)
     append_to_file(ld_script_path.parent / INTERMEDIATE_D_NAME, main_exe_output)
 
-    if args.verbose:
-        print(f"✅ alessatool/generate: wrote linker dependencies to {output_path}")
-
 def generate_lcf(args: GenerationArgs):
     '''
     Generate a linker command file. It uses an oversimplified method of looping

--- a/tools/alessatool/commands/generate.py
+++ b/tools/alessatool/commands/generate.py
@@ -126,7 +126,7 @@ def generate_linker_dependencies(args: GenerationArgs):
     for path_str in path_strs:
         output += f"{path_str}:\n"
 
-    output_path = ld_script_path.with_suffix(".d"),
+    output_path = ld_script_path.with_suffix(".d")
     ensure_path_and_write(output_path, output)
     append_to_file(ld_script_path.parent / INTERMEDIATE_D_NAME, main_exe_output)
 

--- a/tools/alessatool/commands/generate.py
+++ b/tools/alessatool/commands/generate.py
@@ -126,8 +126,12 @@ def generate_linker_dependencies(args: GenerationArgs):
     for path_str in path_strs:
         output += f"{path_str}:\n"
 
-    ensure_path_and_write(ld_script_path.with_suffix(".d"), output)
+    output_path = ld_script_path.with_suffix(".d"),
+    ensure_path_and_write(output_path, output)
     append_to_file(ld_script_path.parent / INTERMEDIATE_D_NAME, main_exe_output)
+
+    if args.verbose:
+        print(f"✅ alessatool/generate: wrote linker dependencies to {output_path}")
 
 def generate_lcf(args: GenerationArgs):
     '''

--- a/tools/alessatool/commands/generate.py
+++ b/tools/alessatool/commands/generate.py
@@ -16,7 +16,9 @@ import os
 import json
 from pathlib import Path
 from dataclasses import dataclass, asdict
-from utils import ensure_path_and_write, normalize_object_path, to_expected_path
+
+from utils import append_to_file, ensure_path_and_write, normalize_object_path, to_expected_path
+from constants import INTERMEDIATE_D_NAME
 
 import splat.scripts.split as split
 import splat.util.options as splat_options
@@ -44,6 +46,7 @@ class GenerationArgs:
     build_path: Path
     verbose: bool
     no_lcf: bool
+    no_dependencies: bool
     no_objdiff: bool
     use_cache: bool
     yamls: list[str]
@@ -80,7 +83,8 @@ def split_yaml(args: GenerationArgs) -> None:
             use_cache=args.use_cache,
             make_full_disasm_for_code=args.make_full_disasm_for_code
         )
-        generate_linker_dependencies(args)
+        if not args.no_dependencies:
+            generate_linker_dependencies(args)
     finally:
         os.chdir(old_cwd)
 
@@ -103,20 +107,27 @@ def generate_linker_dependencies(args: GenerationArgs):
     build_path = args.build_path
     path_strs = []
 
-    output = f"{(build_path / clean_up_path(splat_options.opts.elf_path)).as_posix()}:"
+    elf_path = splat_options.opts.elf_path
+    ld_script_path = splat_options.opts.ld_script_path
+    output = f"{(build_path / clean_up_path(elf_path)).as_posix()}:"
+    main_exe_output = ""
 
     for entry in linker_writer.dependencies_entries:
         if entry.object_path is None:
             continue
         path_str = normalize_object_path(entry.object_path, build_path)
         path_strs.append(path_str)
+
         output += f" \\\n    {path_str}"
+        main_exe_output += f"    {path_str} \\\n"
 
     output += "\n"
+
     for path_str in path_strs:
         output += f"{path_str}:\n"
-    
-    ensure_path_and_write(splat_options.opts.ld_script_path.with_suffix(".d"), output)
+
+    ensure_path_and_write(ld_script_path.with_suffix(".d"), output)
+    append_to_file(ld_script_path.parent / INTERMEDIATE_D_NAME, main_exe_output)
 
 def generate_lcf(args: GenerationArgs):
     '''

--- a/tools/alessatool/commands/merge.py
+++ b/tools/alessatool/commands/merge.py
@@ -1,8 +1,14 @@
 '''
 alessatool/merge:
 
-merge objdiff units. this is helper script that takes a list of objdiff.json
-files from `alessatool generate` and combines them into one.
+merge temporary files. it has two modes:
+
+- `objdiff`: merge objdiff units. this is helper script that takes a list of
+  objdiff.json files from `alessatool generate` and combines them into one.
+
+- `dependencies`: merge `.d` files. splat can only see the dependencies
+  belonging to a single yaml, so we combine them to pass all object files to
+  mwld.  
 
 see `alessatool merge --help` for more information.
 '''

--- a/tools/alessatool/commands/merge.py
+++ b/tools/alessatool/commands/merge.py
@@ -10,13 +10,17 @@ see `alessatool merge --help` for more information.
 from pathlib import Path
 from dataclasses import dataclass
 from json import load, dumps
-from utils import ensure_path_and_write
+
+from constants import INTERMEDIATE_D_NAME
+from utils import ensure_path_and_write, remove_file
 
 @dataclass
 class MergeArgs:
+    mode: str
     objdiff_fragments: list[Path]
     categories_path: Path
-    output_path: Path
+    objdiff_output_path: Path
+    d_path: Path
     verbose: bool
 
 def merge_objdiff_units(args: MergeArgs):
@@ -45,7 +49,41 @@ def merge_objdiff_units(args: MergeArgs):
         "units": units,
     })
 
-    ensure_path_and_write(args.output_path, result)
+    ensure_path_and_write(args.objdiff_output_path, result)
 
     if args.verbose:
         print(f"🟣 alessatool/merge: wrote objdiff.json")
+
+def merge_linker_dependencies(args: MergeArgs):
+    d_path = args.d_path
+    all_d_path = args.d_path.parent / INTERMEDIATE_D_NAME
+
+    with open(d_path) as d_file:
+        d_lines = d_file.readlines()
+
+    with open(all_d_path) as all_d_file:
+        all_d_contents = all_d_file.read() + "\n\n"
+
+    for index in range(1, len(d_lines)):
+        if not d_lines[index].startswith(" "): break
+
+    merged = d_lines[0] + all_d_contents + "".join(d_lines[index:])
+
+    with open(d_path.with_suffix(".d"), "w") as d_file:
+        d_file.write(merged)
+
+    remove_file(all_d_path)
+
+    if args.verbose:
+        print(f"🟣 alessatool/merge: wrote f{d_file.name}")
+
+def merge_fragments(args: MergeArgs):
+    match args.mode:
+        case "objdiff":
+            merge_objdiff_units(args)
+
+        case "dependencies":
+            merge_linker_dependencies(args)
+
+        case _:
+            raise Exception(f"unknown merge mode {args.mode}")

--- a/tools/alessatool/commands/merge.py
+++ b/tools/alessatool/commands/merge.py
@@ -53,6 +53,12 @@ def merge_objdiff_units(args: MergeArgs):
         "build_base": True,
         "build_target": False,
         "custom_args": [f"PROJECT={args.project}", "report", "-j"],
+        "watch_patterns": [
+            "*.c",
+            "*.h",
+            "*.txt",
+            "*.json"
+        ],
         "progress_categories": progress_categories,
         "units": units,
     })

--- a/tools/alessatool/commands/merge.py
+++ b/tools/alessatool/commands/merge.py
@@ -28,6 +28,7 @@ class MergeArgs:
     objdiff_output_path: Path
     d_path: Path
     verbose: bool
+    project: Path
 
 def merge_objdiff_units(args: MergeArgs):
     units = []
@@ -49,8 +50,9 @@ def merge_objdiff_units(args: MergeArgs):
 
     result = dumps({
         "$schema": "https://raw.githubusercontent.com/encounter/objdiff/main/config.schema.json",
-        "build_base": False,
+        "build_base": True,
         "build_target": False,
+        "custom_args": [f"PROJECT={args.project}", "report", "-j"],
         "progress_categories": progress_categories,
         "units": units,
     })

--- a/tools/alessatool/commands/util.py
+++ b/tools/alessatool/commands/util.py
@@ -27,5 +27,6 @@ class LowercaseArgs:
     folder_path: Path
 
 def make_folder_lowercase(args: LowercaseArgs):
+    print(args)
     for file_path in args.folder_path.glob("*"):
         file_path.rename(file_path.parent / file_path.name.lower())

--- a/tools/alessatool/constants.py
+++ b/tools/alessatool/constants.py
@@ -3,6 +3,11 @@ SH2_SERIAL = "SLUS_202.28"
 SERIAL = SH3_SERIAL
 MFA_ARCHIVE = "B0.MFA"
 
+PROJECT_CONFIGURATIONS = {
+    "silent-hill-2": SH2_SERIAL,
+    "silent-hill-3": SH3_SERIAL,
+}
+
 ASM = "asm"
 BUILD = "build"
 CONFIG = "config"
@@ -19,3 +24,5 @@ SECTION_DIRECTIVE = ".section "
 TEXT_SECTION_DIRECTIVE = ".section .text"
 UNIQUE_TEXT_SECTION_DIRECTIVE = '.section .text,"ax",@progbits,unique,'
 INCLUDE_MACRO_INC_DIRECTIVE = '.include "macro.inc"'
+
+INTERMEDIATE_D_NAME = "all.d"

--- a/tools/alessatool/utils.py
+++ b/tools/alessatool/utils.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from constants import ASM, SRC
-from os import stat
+from os import stat, remove
 
 def normalize_object_path(path: Path, prefix_path: Path):
     '''
@@ -41,6 +41,13 @@ def ensure_path_and_write(output_path: Path, contents: str):
     output_path.parent.mkdir(exist_ok=True, parents=True)
     with open(output_path, "w") as f:
         f.write(contents)
+
+def append_to_file(output_path: Path, contents: str):
+    with open(output_path, "a") as f:
+        f.write(contents)
+
+def remove_file(path: Path):
+    remove(path)
 
 def get_file_size(file_path: Path):
     return stat(file_path).st_size


### PR DESCRIPTION
on main doing `make sh2-report -j` and then `make sh2 -j` without cleaning would cause the expected objects to be linked. this branch fixes that, while still keeping incremental builds, which should make working with objdiff and checking linking simultaneously much faster.

i wasn't handing the dependencies properly because splat assumes overlays can be linked independently, but mwld needs the main exe to depend on / be passed all object files including the overlays.
