### PR TITLE
build system & documentation updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,13 +51,13 @@ jobs:
         run: cp -r /home/* .
 
       - name: build matching executable
-        run: make -j $(nproc) ${{ matrix.TARGET.ALIAS }}
+        run: make ${{ matrix.TARGET.ALIAS }}
       
       - name: clean build files
         run: make ${{ matrix.TARGET.ALIAS }}-clean
 
       - name: make report
-        run: make -j $(nproc) ${{ matrix.TARGET.ALIAS }}-report
+        run: make ${{ matrix.TARGET.ALIAS }}-report
 
       - name: upload to silenthillmuseum.org
         env:

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,10 @@ PROJECT ?= silent-hill-3
 NON_MATCHING ?= 0
 GENERATE_LCF ?= 1
 GENERATE_REPORT ?= 0
+
 VERBOSE ?= 0
+NPROC ?= $(call get_nproc)
+MAKEFLAGS += -j$(NPROC)
 ###############################################################
 SHELL := /bin/sh
 ARCH := $(shell uname -m)
@@ -261,6 +264,7 @@ debug:
 	@echo "$(SOURCE_PREREQS)"
 	@echo "$(TARGETS)"
 	@echo "$(BINARIES:%=$(LINKERS)/%.d)"
+	@echo "NPROC=$(NPROC)"
 	@echo '---'
 
 diff:
@@ -293,7 +297,7 @@ $(LINKERS)/%.d: $(CONFIG)/%.yaml $(SPLAT_FILES) $(SETUP)
 	$(GENERATE) $(GENERATE_FLAGS) $(SPLAT_CONFIG) $<
 
 $(TARGET_EXECUTABLE): $(SETUP) $(OVERLAY_TARGETS) $(LINKER_SCRIPT)
-	@echo "* linking with mwld..."
+	@echo "* linking..."
 	$(Q)$(LD)
 	$(CHECK_MATCH_PERCENT)
 
@@ -374,6 +378,11 @@ $(patsubst $(ASM)/%.s,$(BUILD)/asm/%.s.o, \
 	$(shell find $(ASM) \
 		-type d \( -name matchings -o -name nonmatchings \) \
 		-prune -false -o -type f -name '*.s'))
+endef
+define get_nproc
+$(strip $(if $(filter $(PLATFORM),linux), \
+	 		 $(shell nproc), \
+	 		 $(shell sysctl -n hw.logicalcpu)))
 endef
 ###############################################################
 PHONY_TARGETS := \

--- a/Makefile
+++ b/Makefile
@@ -265,12 +265,7 @@ death:
 	$(GIT) submodule foreach --recursive $(GIT) reset --hard
 
 debug:
-	@echo "$(YAMLS)"
-	@echo "$(SOURCE_PREREQS)"
-	@echo "$(TARGETS)"
-	@echo "$(BINARIES:%=$(LINKERS)/%.d)"
-	@echo "$(NPROC)"
-	@echo '---'
+	$(ALESSATOOL) debug
 
 diff:
 	$(CHECK_MATCH_PERCENT)

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ endif
 
 MAKE += MAKE_OPTIONS=""
 MAKEFLAGS += $(MAKE_OPTIONS)
+
 include $(PROJECT)/Makefile
 ###############################################################
 BINARIES := $(SERIAL) $(OVERLAYS)

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,10 @@ GENERATE_LCF ?= 1
 GENERATE_REPORT ?= 0
 
 VERBOSE ?= 0
+TQDM_DISABLE ?= 1
+
 NPROC ?= $(call get_nproc)
-MAKEFLAGS += -j$(NPROC)
+MAKE_OPTIONS ?= -j$(NPROC)
 ###############################################################
 SHELL := /bin/sh
 ARCH := $(shell uname -m)
@@ -44,7 +46,6 @@ KERNEL := $(shell uname -s)
 PLATFORM := $(if $(filter $(KERNEL),Darwin),macos,linux)
 OS := $(PLATFORM)-$(subst _,-,$(ARCH))
 
-MAKE := make
 GIT := git
 PYTHON := python3
 PIP := $(PYTHON) -m pip
@@ -61,6 +62,13 @@ INCLUDE = $(PROJECT)/include
 SRC = $(PROJECT)/src
 COMMON_INCLUDE = include
 
+Q := @
+ifeq ($(VERBOSE),1)
+	Q :=
+endif
+
+MAKE += MAKE_OPTIONS=""
+MAKEFLAGS += $(MAKE_OPTIONS)
 include $(PROJECT)/Makefile
 ###############################################################
 BINARIES := $(SERIAL) $(OVERLAYS)
@@ -87,7 +95,6 @@ SPLAT_FILES := $(SPLAT_CONFIG) $(wildcard $(CONFIG)/*.txt)
 OVERLAY_SPLAT_FILES = $(CONFIG)/overlay/%_symbol_addrs.txt
 LINKER_TEMPLATE := $(INCLUDE)/$(SERIAL).inc.lcf
 ###############################################################
-
 BINUTILS_FLAVOR := mips-ps2-decompals
 BINUTILS := $(TOOLS)/binutils-$(BINUTILS_FLAVOR)
 BINUTILS_VERSION_FILE := $(BINUTILS)/version-0-10
@@ -145,7 +152,8 @@ CREATE_OBJDIFF_CONFIG = $(ALESSATOOL) merge objdiff \
 
 ALESSATOOL := $(PYTHON) $(TOOLS)/alessatool/alessatool.py --verbose
 ALESSATOOL_OVERLAY_LOCK := $(OVERLAY_SOURCE_DIR)/.lock
-GENERATE := $(ALESSATOOL) generate \
+GENERATE := $(Q)TQDM_DISABLE=$(TQDM_DISABLE) \
+	$(ALESSATOOL) generate \
 	--template-path $(LINKER_TEMPLATE) \
 	--lcf-output-path $(LINKERS)/$(SERIAL).lcf \
 	--build-path $(BUILD) \
@@ -174,7 +182,8 @@ GENERATE_EXPECTED := $(GENERATE) --no-lcf --make-full-disasm-for-code
 CHECK_MATCH_PERCENT :=
 ifneq ($(NON_MATCHING),1)
 ifneq ($(LINK),0)
-	CHECK_MATCH_PERCENT = @$(TOOLS)/scripts/diff.sh $(SERIAL) $(CONFIG) $(BUILD) $(OBJCOPY)
+	CHECK_MATCH_PERCENT = @$(TOOLS)/scripts/diff.sh $(SERIAL) $(CONFIG) $(BUILD) $(OBJCOPY) \
+		|| $(ALESSATOOL) debug --project=$(PROJECT)
 endif
 endif
 
@@ -186,45 +195,40 @@ WIBO_HOST := https://github.com/decompals/wibo/releases/download/1.0.1
 COMPILERS_HOST := https://github.com/decompme/compilers/releases/download/compilers
 BINUTILS_HOST := https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.10
 OBJDIFF_HOST := https://github.com/encounter/objdiff/releases/download/v3.6.0
-
-Q := @
-ifeq ($(VERBOSE),1)
-	Q :=
-endif
 ###############################################################
 all: $(TARGETS)
 
 setup: $(SETUP)
 
 report: $(SETUP) $(OBJDIFF) $(OBJDIFF_CONFIG)
-	$(MAKE) clean-quick
+	@$(MAKE) clean-quick
 	@$(MAKE) expected
 	@$(OBJDIFF) report generate -o $(BUILD)/report.json
 
 build:
-	$(MAKE) clean-quick
-	$(MAKE)
+	@$(MAKE) clean-quick
+	@$(MAKE)
 
 sh3:
-	$(MAKE) PROJECT="silent-hill-3"
+	@$(MAKE) PROJECT="silent-hill-3"
 
 sh2:
-	$(MAKE) PROJECT="silent-hill-2"
+	@$(MAKE) PROJECT="silent-hill-2"
 
 sh3-build:
-	$(MAKE) PROJECT="silent-hill-3" build
+	@$(MAKE) PROJECT="silent-hill-3" build
 
 sh2-build:
-	$(MAKE) PROJECT="silent-hill-2" build
+	@$(MAKE) PROJECT="silent-hill-2" build
 
 sh3-report:
-	$(MAKE) PROJECT="silent-hill-3" report
+	@$(MAKE) PROJECT="silent-hill-3" report
 
 sh2-report:
-	$(MAKE) PROJECT="silent-hill-2" report
+	@$(MAKE) PROJECT="silent-hill-2" report
 
 sh3-clean:
-	$(MAKE) PROJECT="silent-hill-3" clean-project
+	@$(MAKE) PROJECT="silent-hill-3" clean-project
 
 sh2-clean:
 	$(MAKE) PROJECT="silent-hill-2" clean-project
@@ -264,7 +268,7 @@ debug:
 	@echo "$(SOURCE_PREREQS)"
 	@echo "$(TARGETS)"
 	@echo "$(BINARIES:%=$(LINKERS)/%.d)"
-	@echo "NPROC=$(NPROC)"
+	@echo "$(NPROC)"
 	@echo '---'
 
 diff:
@@ -272,9 +276,9 @@ diff:
 
 expected: $(YAMLS)
 	@mkdir -p "$(@D)"
-	$(MAKE) $(OBJDIFF_CONFIG)
-	$(MAKE) NON_MATCHING=1 $(call get_c_objects)
-	$(MAKE) $(call get_asm_objects)
+	@$(MAKE) $(OBJDIFF_CONFIG)
+	@$(MAKE) NON_MATCHING=1 $(call get_c_objects)
+	@$(MAKE) $(call get_asm_objects)
 
 compiler-info:
 	$(WIBO) $(MWCC) -help

--- a/Makefile
+++ b/Makefile
@@ -185,17 +185,61 @@ OBJDIFF_HOST := https://github.com/encounter/objdiff/releases/download/v3.6.0
 ###############################################################
 all: $(TARGETS)
 
+setup: $(SETUP)
+
 report: $(SETUP) $(OBJDIFF) $(OBJDIFF_CONFIG)
+	$(MAKE) clean-quick
 	@$(MAKE) expected
 	@$(OBJDIFF) report generate -o $(BUILD)/report.json
 
-split: $(D_FILES) $(SPLAT_FILES)
-
-setup: $(SETUP)
-
-rebuild:
-	rm -rf $(BUILD)
+build:
+	$(MAKE) clean-quick
 	$(MAKE)
+
+sh3:
+	$(MAKE) PROJECT="silent-hill-3"
+
+sh2:
+	$(MAKE) PROJECT="silent-hill-2"
+
+sh3-build:
+	$(MAKE) PROJECT="silent-hill-3" build
+
+sh2-build:
+	$(MAKE) PROJECT="silent-hill-2" build
+
+sh3-report:
+	$(MAKE) PROJECT="silent-hill-3" report
+
+sh2-report:
+	$(MAKE) PROJECT="silent-hill-2" report
+
+sh3-clean:
+	$(MAKE) PROJECT="silent-hill-3" clean-project
+
+sh2-clean:
+	$(MAKE) PROJECT="silent-hill-2" clean-project
+
+clean:
+	@$(MAKE) PROJECT=silent-hill-3 clean-project
+	@$(MAKE) PROJECT=silent-hill-2 clean-project
+
+clean-build:
+	@$(MAKE) PROJECT=silent-hill-3 clean-project-build
+	@$(MAKE) PROJECT=silent-hill-2 clean-project-build
+
+clean-quick:
+	rm -f $(OBJDIFF_CONFIG)
+	rm -rf $(BUILD)/src
+
+clean-project-build:
+	rm -rf $(BUILD)
+
+clean-project:
+	rm -rf $(ASM)
+	rm -rf $(ASSETS)
+	rm -rf $(BUILD)
+	rm -rf $(LINKERS)
 
 death:
 	@$(MAKE) clean
@@ -228,51 +272,13 @@ compiler-info:
 linker-info:
 	$(WIBO) $(MWLD) -help
 
-alessatool:
-	$(ALESSATOOL)
-
 binutils: $(AS)
-
-clean:
-	@$(MAKE) PROJECT=silent-hill-3 clean-project
-	@$(MAKE) PROJECT=silent-hill-2 clean-project
-
-clean-build:
-	@$(MAKE) PROJECT=silent-hill-3 clean-project-build
-	@$(MAKE) PROJECT=silent-hill-2 clean-project-build
-
-clean-project-build:
-	rm -rf $(BUILD)
-
-clean-project:
-	rm -rf $(ASM)
-	rm -rf $(ASSETS)
-	rm -rf $(BUILD)
-	rm -rf $(LINKERS)
 
 extract: $(SOURCE_OVERLAY_ARCHIVE)
 	$(ALESSATOOL) $(EXTRACT)
 
 overlays-lowercase:
 	$(ALESSATOOL) util lowercase --folder-path $(ROM)/overlay
-
-sh3:
-	$(MAKE) PROJECT="silent-hill-3"
-
-sh2:
-	$(MAKE) PROJECT="silent-hill-2"
-
-sh3-report:
-	$(MAKE) PROJECT="silent-hill-3" report
-
-sh2-report:
-	$(MAKE) PROJECT="silent-hill-2" report
-
-sh3-clean:
-	$(MAKE) PROJECT="silent-hill-3" clean-project
-
-sh2-clean:
-	$(MAKE) PROJECT="silent-hill-2" clean-project
 ###############################################################
 $(LINKERS)/%.d: $(CONFIG)/overlay/%.yaml $(OVERLAY_SPLAT_FILES) $(SETUP)
 	$(GENERATE) $(GENERATE_OVERLAY_FLAGS) $(SPLAT_CONFIG) $<
@@ -362,11 +368,13 @@ $(patsubst $(ASM)/%.s,$(BUILD)/asm/%.s.o, \
 endef
 ###############################################################
 PHONY_TARGETS := \
-	alessatool binutils clean clean-build clean-project \
-	clean-project-build compiler-info death debug deep-clean \
-	diff expected extract heaven hell linker-info progress \
+	alessatool binutils build clean clean-build \
+	clean-quick clean-project clean-project-build \
+	compiler-info death debug deep-clean diff expected \
+	extract heaven hell linker-info progress \
 	overlays-lowercase rebuild report setup sh2 sh3 \
-	sh2-clean sh3-clean sh2-report sh3-report split
+	sh2-build sh3-build sh2-clean sh3-clean \
+	sh2-report sh3-report split
 .PHONY: $(PHONY_TARGETS)
 ifeq ($(filter $(PHONY_TARGETS) $(OBJDIFF_CONFIG),$(MAKECMDGOALS)),)
 -include $(BINARIES:%=$(LINKERS)/%.d)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ PROJECT ?= silent-hill-3
 NON_MATCHING ?= 0
 GENERATE_LCF ?= 1
 GENERATE_REPORT ?= 0
+VERBOSE ?= 0
 ###############################################################
 SHELL := /bin/sh
 ARCH := $(shell uname -m)
@@ -182,6 +183,11 @@ WIBO_HOST := https://github.com/decompals/wibo/releases/download/1.0.1
 COMPILERS_HOST := https://github.com/decompme/compilers/releases/download/compilers
 BINUTILS_HOST := https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.10
 OBJDIFF_HOST := https://github.com/encounter/objdiff/releases/download/v3.6.0
+
+Q := @
+ifeq ($(VERBOSE),1)
+	Q :=
+endif
 ###############################################################
 all: $(TARGETS)
 
@@ -287,16 +293,19 @@ $(LINKERS)/%.d: $(CONFIG)/%.yaml $(SPLAT_FILES) $(SETUP)
 	$(GENERATE) $(GENERATE_FLAGS) $(SPLAT_CONFIG) $<
 
 $(TARGET_EXECUTABLE): $(SETUP) $(OVERLAY_TARGETS) $(LINKER_SCRIPT)
-	$(LD)
+	@echo "* linking with mwld..."
+	$(Q)$(LD)
 	$(CHECK_MATCH_PERCENT)
 
 $(BUILD)/%.c.o: $(PROJECT)/%.c
 	@mkdir -p "$(@D)"
-	$(CC)
+	@echo "* $(@)"
+	$(Q)$(CC)
 
 $(BUILD)/%.s.o: $(CONFIG)/%.s
 	@mkdir -p "$(@D)"
-	$(AS) $(AS_FLAGS) -o "$@" "$<"
+	@echo "* $(@)"
+	$(Q)$(AS) $(AS_FLAGS) -o "$@" "$<"
 
 $(LINKER_SCRIPT): $(SPLAT_CONFIG) $(CONFIG)/$(SERIAL).yaml $(LINKER_TEMPLATE)
 	$(GENERATE) $(GENERATE_FLAGS) $(SPLAT_CONFIG) $(CONFIG)/$(SERIAL).yaml

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -67,8 +67,9 @@ Submitting changes to the repository looks like so:
    information).
 2. Find the `INCLUDE_ASM` line where the function is referenced and replace it with the decompiled code.
 3. Update or create any other files as needed, including header files.
-4. Recommended: Run `make clean`, then `make sh3-report -j`. Open objdiff from the root directory of this repository and check the status of the functions.
-5. Run `make clean`, then `make -j` to make sure the build is passing.
+4. Recommended: Run `make clean`, then `make sh3-report`. Open objdiff from the
+   root directory of this repository and check the status of the functions.
+5. Run `make clean`, then `make` to make sure the build is passing.
 
 Once that's done, feel free to [submit a pull request](https://github.com/dreamingmoths/memory-of-alessa/pulls)! Please try
 your best to submit changes that keep the build matching, but if you run into

--- a/docs/development.md
+++ b/docs/development.md
@@ -78,11 +78,6 @@ alessatool annotate --asm-path silent-hill-2/config/SLUS_202.28/asm/Chacter_Draw
 
 See `alessatool annotate -h` or `alessatool -h` for more information.
 
-### matching code
-
-To match code, you may use [decomp.me](https://decomp.me). Find an assembly
-file located in `silent-hill-3/config/SLUS_206.22/asm` 
-
 ## general workflow & `make` commands
 
 Usual development can be thought of in two distinct phases:

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,12 +30,12 @@ After running `make`, there will be assembly files located at
 `build/SLUS_206.22`. The build process should link back to a 100% matching ELF
 of Silent Hill 3, along with its 40 overlays.
 
-Note the Makefile is a work in progress. You may often need to clean the build
-for it to rebuild properly, e.g.:
+Before submitting contributions, we recommend building from clean to ensure
+everything is in order.
 
 ```sh
 make clean # cleans up all generated files
-make -j8   # re-runs the build with 8 parallel jobs
+make       # re-runs the build with maximum parallel jobs
 ```
 
 Since this project is dedicated to Silent Hill 3, why a shared repo?
@@ -65,60 +65,6 @@ As of June 21st, 2026, this command should also properly link back into a
 matching build of Silent Hill 2. It will create assembly files at
 `silent-hill-2/config/SLUS_202.28/asm`.
 
-### ghidra bsim workflow
-
-[Ghidra](https://github.com/NationalSecurityAgency/ghidra) makes the dual
-decompilation approach significantly more viable through its [BSim
-plugin](https://ghidra.re/ghidra_docs/GhidraClass/BSim/README.html), which
-allows us to search for similar functions. It works like so:
-
-1. Find an interesting function in SH2. Make use of Ghidra BSim to look for a
-   similar function in SH3. (Follow the tutorial linked above to get BSim set
-   up.)
-
-2. Decompile a function from SH2.
-
-3. Use the result as a starting point for decompiling the SH3 function, editing
-   it until it matches.
-
-### `make` commands
-
-For a local [`objdiff`](https://github.com/encounter/objdiff) workflow, generate
-the expected files with the following command.
-
-```sh
-make report
-```
-
-You may also use the project-specific commands `make sh2-report` and `make sh3-report`.
-
-To quickly clean the build folder and rebuild all object files, run
-
-```sh
-make rebuild -j
-```
-
-though most of the time you may only need `make -j`.
-
-There are a couple of ways to clean the SH2 directory.
-
-```sh
-# pass the `PROJECT` build argument
-make PROJECT=silent-hill-2 clean
-
-# run the alias
-make sh2-clean
-```
-
-To clean generated files in both projects, run
-
-```sh
-make clean
-```
-
-or to really delete all setup and reset, run `make death`. This shouldn't be
-necessary in most cases though.
-
 ### `alessatool` commands
 
 To make full use of the debug information from Silent Hill 2, we need to add the
@@ -137,14 +83,99 @@ See `alessatool annotate -h` or `alessatool -h` for more information.
 To match code, you may use [decomp.me](https://decomp.me). Find an assembly
 file located in `silent-hill-3/config/SLUS_206.22/asm` 
 
-#### sh3 compiler flags
+## general workflow & `make` commands
+
+Usual development can be thought of in two distinct phases:
+
+1. Linking phase. Here we are making sure that the code builds properly and
+   links into a matching executable that can run on a PlayStation 2.
+2. Diffing phase. In this phase we are decompiling the code, typically with
+   [objdiff](https://github.com/encounter/objdiff) when running locally or using
+   [decomp.me](https://decomp.me/).
+
+The linking phase is the default as it helps ensure everything is working
+correctly. The following commands are recommended during the linking phase.
 
 ```sh
--O3,p -sym=off,noelf -sdatathreshold 0
+make sh3-build
+make sh2-build
 ```
 
-#### sh2 compiler flags
+Note that you can get faster, incremental builds by leaving out the `-build`
+part of the command, e.g.
 
 ```sh
--O2,p -sym=on -str readonly -sdatathreshold 0 -enum min
+make
+make sh2
 ```
+
+however these will not always work correctly.*
+
+To enter the diffing phase, run one of the following commands to generate the
+expected files.
+
+```sh
+make sh3-report
+make sh2-report
+```
+
+Once these files have been generated, you may open the objdiff gui from the root
+of the repository. It will watch for changes to the source files and
+automatically rebuild as necessary, though changes to any configuration files
+such as the Splat YAML will require the report command to be repeated manually.
+
+```sh
+# make sure objdiff is on PATH, or pass the full path to the executable
+objdiff-linux-x86_64
+objdiff-macos-arm64
+```
+
+In general, build files for both Silent Hill 2 and 3 can be on disk
+simultaneously without overwriting each other, with the exception of the objdiff
+configuration that is named `objdiff.json` so it can be easily picked up by
+objdiff.
+
+Before submitting or merging a pull request, please ensure the project builds
+from a clean environment.
+
+```sh
+make clean
+make sh2
+make sh3
+```
+
+Here are some other useful commands.
+
+```sh
+make compiler-info > out.log # logs the mwcc help to a file
+make linker-info             # logs the mwld help
+make overlays-lowercase      # renames overlay filenames
+make debug                   # runs `alessatool debug`
+make death                   # really resets most things (!?)
+
+make VERBOSE=1               # see what commands are being run
+make PROJECT=silent-hill-2   # you may always pass `PROJECT=` instead of `sh2-`
+make NPROC=1                 # build without parallelism
+```
+
+(*) In particular, `make sh3` will not always work when moving from the diffing
+phase to the linking phase, because the linked C objects are different from the
+ones used to generate the report. They also may not always rebuild properly
+because the Makefile does not use generated dependency (.d) files from MWCC.
+This is why `make sh3-build` is preferred when speed is not highest priority.
+
+### ghidra bsim workflow
+
+[Ghidra](https://github.com/NationalSecurityAgency/ghidra) makes the dual
+decompilation approach significantly more viable through its [BSim
+plugin](https://ghidra.re/ghidra_docs/GhidraClass/BSim/README.html), which
+allows us to search for similar functions. It works like so:
+
+1. Find an interesting function in SH2. Make use of Ghidra BSim to look for a
+   similar function in SH3. (Follow the tutorial linked above to get BSim set
+   up.)
+
+2. Decompile a function from SH2.
+
+3. Use the result as a starting point for decompiling the SH3 function, editing
+   it until it matches.

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,7 @@ To make full use of the debug information from Silent Hill 2, we need to add the
 line numbers to the assembly. Example:
 
 ```sh
-make sh2-report -j
+make sh2-report
 source tools/scripts/env.sh # will make `alessatool` available
 alessatool annotate --asm-path silent-hill-2/config/SLUS_202.28/asm/Chacter_Draw/model3_sub_n.s
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -155,9 +155,10 @@ make NPROC=1                 # build without parallelism
 
 (*) In particular, `make sh3` will not always work when moving from the diffing
 phase to the linking phase, because the linked C objects are different from the
-ones used to generate the report. They also may not always rebuild properly
-because the Makefile does not use generated dependency (.d) files from MWCC.
-This is why `make sh3-build` is preferred when speed is not highest priority.
+ones used to generate the report. It also may not always detect source file
+changes as the Makefile currently only uses dependency (.d) files from Splat and
+not the compiler. This is why `make sh3-build` is preferred when speed is not
+highest priority.
 
 ### ghidra bsim workflow
 

--- a/silent-hill-3/src/Event/stage/amusement_01.c
+++ b/silent-hill-3/src/Event/stage/amusement_01.c
@@ -1002,7 +1002,9 @@ int func_01F6FDC0_amusement_01(void) {
     }
 }
 
+#pragma supress_warnings on
 UNCURSE_AMUSEMENT_MOON();
+#pragma supress_warnings off
 
 int func_01F6FED0_amusement_01(void) {
     switch (D_01F74C88_amusement_01) {

--- a/silent-hill-3/src/Event/stage/construct_00.c
+++ b/silent-hill-3/src/Event/stage/construct_00.c
@@ -37,7 +37,9 @@ int func_01F6D680_construct_00(void) {
     return ret;
 }
 
+#pragma supress_warnings on
 UNCURSE_CONSTRUCT_MOON();
+#pragma supress_warnings off
 
 int func_01F6D7E0_construct_00(void) { //check 3th floor sign
     float volume, zero;

--- a/silent-hill-3/src/Event/stage/hospital_f_03.c
+++ b/silent-hill-3/src/Event/stage/hospital_f_03.c
@@ -1,6 +1,8 @@
 #include "hospital_f_03.h"
 
+#pragma supress_warnings on
 UNCURSE_HOSPITAL_MOON();
+#pragma supress_warnings off
 
 int func_01F6D680_hospital_f_03(void) {
     int ret;

--- a/tools/alessatool/commands/debug.py
+++ b/tools/alessatool/commands/debug.py
@@ -267,7 +267,5 @@ def debug_nonmatching(args: DebugArgs):
     mapfile_path = Path(BUILD) / serial / f"{serial}.xMAP"
     if mapfile_path.exists():
         parse_mw_mapfile(mapfile_path, exe_info_by_name, args)
-    else:
-        print(f"{mapfile_path.as_posix()} not found, please run the build to debug")
 
     run_bin_diff(args, debug_info, exe_info_by_name)


### PR DESCRIPTION
- document general workflow in development.md
- add more makefile options, reduce logging during build
- use `#pragma supress_warnings` in a few places (it's really spelled like that, at least the reference tells it)
- automatically run `alessatool debug` when the build does not match

after recent changes, the build should hopefully be more stable in general (ignoring mwcc holy candle situations), and we should not have to run `make clean` as often when using the new `make build` command