### PR TITLE
sh3: reorder `SeCall` arguments

### DIFF
--- a/silent-hill-3/src/Event/stage/amusement_00.c
+++ b/silent-hill-3/src/Event/stage/amusement_00.c
@@ -241,14 +241,14 @@ int func_01F6E590_amusement_00(void) {
     switch (D_01F72D80_amusement_00) {
     case 0:
         func_00190A20(2);
-        SeCall(1.0f, 0.0f, 0x4A51);
+        SeCall(0x4A51, 0.0f, 1.0f);
         D_01F72D80_amusement_00++;
     case 1:
         if (func_0016C1C0(0x3F) == 0) {
             return 0;
         }
         func_001C2290(0.5f, 3);
-        SeCall(1.0f, 0.0f, 0x4A4F);
+        SeCall(0x4A4F, 0.0f, 1.0f);
         D_01F72D80_amusement_00++;
     case 2:
         if (func_001C2580(2) == 0) {

--- a/silent-hill-3/src/Event/stage/amusement_00.c
+++ b/silent-hill-3/src/Event/stage/amusement_00.c
@@ -241,14 +241,14 @@ int func_01F6E590_amusement_00(void) {
     switch (D_01F72D80_amusement_00) {
     case 0:
         func_00190A20(2);
-        SeCall(0x4A51, 0.0f, 1.0f);
+        SeCall(19025, 0.0f, 1.0f);
         D_01F72D80_amusement_00++;
     case 1:
         if (func_0016C1C0(0x3F) == 0) {
             return 0;
         }
         func_001C2290(0.5f, 3);
-        SeCall(0x4A4F, 0.0f, 1.0f);
+        SeCall(19023, 0.0f, 1.0f);
         D_01F72D80_amusement_00++;
     case 2:
         if (func_001C2580(2) == 0) {

--- a/silent-hill-3/src/Event/stage/amusement_00.h
+++ b/silent-hill-3/src/Event/stage/amusement_00.h
@@ -45,7 +45,7 @@ int func_001C2580(int);
 void func_001EC590(int);
 void func_00258910(void);
 void func_00316C50(int);
-int SeCall(int arg2, float arg1, float arg0);
+extern int SeCall(int, float, float);
 
 extern int D_01F72830_amusement_00;
 extern int D_01F72890_amusement_00;

--- a/silent-hill-3/src/Event/stage/amusement_00.h
+++ b/silent-hill-3/src/Event/stage/amusement_00.h
@@ -45,7 +45,7 @@ int func_001C2580(int);
 void func_001EC590(int);
 void func_00258910(void);
 void func_00316C50(int);
-int SeCall(float arg0, float arg1, int arg2);
+int SeCall(int arg2, float arg1, float arg0);
 
 extern int D_01F72830_amusement_00;
 extern int D_01F72890_amusement_00;

--- a/silent-hill-3/src/Event/stage/amusement_01.c
+++ b/silent-hill-3/src/Event/stage/amusement_01.c
@@ -343,6 +343,7 @@ int func_01F6E220_amusement_01(void) {
     return audioIsPlaying;
 }
 
+#ifdef HOLY_CANDLE
 void func_01F6E2A0_amusement_01(void) {
     SubCharacter* heather;
     sceVu0FMATRIX matrix;
@@ -369,7 +370,7 @@ void func_01F6E2A0_amusement_01(void) {
             func_01F70750_amusement_01();
 
             // spikes falling noise
-            SeCall(1.0f, 0.0f, 0x3BCA);
+            SeCall(0x3BCA, 0.0f, 1.0f);
             /* fallthrough */
 
         case 1:
@@ -406,7 +407,7 @@ void func_01F6E2A0_amusement_01(void) {
             y_1 = matrix[3][1] + D_01F74DC0_amusement_01;
             matrix[3][1] = y_1;
             
-            if (!(y_1 <= -1200.0f)) {
+            if (y_1 > -1200.0f) {
                 if (needs_crouch != 0) {
                     matrix[3][1] = -1000.0f;
                     D_01F74C90_amusement_01 = 3;
@@ -458,7 +459,7 @@ void func_01F6E2A0_amusement_01(void) {
 
             func_001C2B80(1, &matrix);
             D_01F74DC0_amusement_01 = matrix[3][1];
-            D_01F74D88_amusement_01 = SeCall(1.0f, 0.0f, 0x3BCB);
+            D_01F74D88_amusement_01 = SeCall(0x3BCB, 0.0f, 1.0f);
             /* fallthrough */
 
         case 5:
@@ -497,6 +498,9 @@ void func_01F6E2A0_amusement_01(void) {
             break;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/amusement_01", func_01F6E2A0_amusement_01);
+#endif
 
 int func_01F6E710_amusement_01(void) {
     int audioIsPlaying;
@@ -941,6 +945,7 @@ int func_01F6FB50_amusement_01(void) {
     return 1;
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6FC80_amusement_01(void) {
     switch (D_01F74C88_amusement_01) {              /* irregular */
         case 0:
@@ -955,7 +960,7 @@ int func_01F6FC80_amusement_01(void) {
             D_01F74C88_amusement_01 = 2;
             D_1D3169C |= 0x8000;
             ItemGet(0x46U);
-            SeCall(1.0f, 0.0f, 0x2B21);
+            SeCall(0x2B21, 0.0f, 1.0f);
             func_00317490(0x46, 0.2f);
         case 2:
             if (func_0016C1C0(0xBF) == 0) {
@@ -974,7 +979,11 @@ int func_01F6FC80_amusement_01(void) {
             return 1;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/amusement_01", func_01F6FC80_amusement_01);
+#endif
 
+#ifdef HOLY_CANDLE
 int func_01F6FDC0_amusement_01(void) {
     switch (D_01F74C88_amusement_01) {
         case 0:
@@ -985,7 +994,7 @@ int func_01F6FDC0_amusement_01(void) {
             D_01F74C88_amusement_01 = 2;
             D_1D3169C |= 0x10000;
             ItemGet(0x47U);
-            SeCall(1.0f, 0.0f, 0x2B21);
+            SeCall(0x2B21, 0.0f, 1.0f);
             func_00317490(0x47, 0.2f);
             /* fallthrough */
         case 2:
@@ -1001,11 +1010,15 @@ int func_01F6FDC0_amusement_01(void) {
             return 1;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/amusement_01", func_01F6FDC0_amusement_01);
+#endif
 
 #pragma supress_warnings on
 UNCURSE_AMUSEMENT_MOON();
 #pragma supress_warnings off
 
+#ifdef HOLY_CANDLE
 int func_01F6FED0_amusement_01(void) {
     switch (D_01F74C88_amusement_01) {
     case 0:
@@ -1017,7 +1030,7 @@ int func_01F6FED0_amusement_01(void) {
         if (func_001C2580(2) == 0) {
             return 0;
         }
-        SeCall(1.0f, 0.0f, 0x3BC4);
+        SeCall(0x3BC4, 0.0f, 1.0f);
         D_01F74C88_amusement_01 = 2;
         func_001C2290(5, 0.8f);
     case 2:
@@ -1036,6 +1049,9 @@ int func_01F6FED0_amusement_01(void) {
         return 1;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/amusement_01", func_01F6FED0_amusement_01);
+#endif
 
 int func_01F70000_amusement_01(void) {
     switch (D_01F74C88_amusement_01) {
@@ -1081,14 +1097,15 @@ int func_01F70000_amusement_01(void) {
     }
 }
 
+#ifdef HOLY_CANDLE
 int func_01F701B0_amusement_01(void) {
     switch (D_01F74C88_amusement_01) {
         case 0:
             func_00190A20(2);
             D_1D3169C |= 0x100000;
-            SeCall(1.0f, 0.0f, 0x3BC5);
+            SeCall(0x3BC5, 0.0f, 1.0f);
             if (GET_BIT(D_1D3169C, 0x15)) {
-                SeCall(1.0f, 0.0f, 0x4A3B);
+                SeCall(0x4A3B, 0.0f, 1.0f);
             }
             D_01F74C88_amusement_01++;
             /* fallthrough */
@@ -1103,15 +1120,19 @@ int func_01F701B0_amusement_01(void) {
             return 1;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/amusement_01", func_01F701B0_amusement_01);
+#endif
 
+#ifdef HOLY_CANDLE
 int func_01F702A0_amusement_01(void) {
     switch (D_01F74C88_amusement_01) {
         case 0:
             func_00190A20(2);
             D_1D3169C |= 0x200000;
-            SeCall(1.0f, 0.0f, 0x3BC5);
+            SeCall(0x3BC5, 0.0f, 1.0f);
             if (GET_BIT(D_1D3169C, 0x14)) {
-                SeCall(1.0f, 0.0f, 0x4A3B);
+                SeCall(0x4A3B, 0.0f, 1.0f);
             }
             D_01F74C88_amusement_01++;
             /* fallthrough */
@@ -1126,6 +1147,9 @@ int func_01F702A0_amusement_01(void) {
             return 1;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/amusement_01", func_01F702A0_amusement_01);
+#endif
 
 void func_01F70390_amusement_01(void) {
     func_01F703B0_amusement_01(20.0f, 40.0f);

--- a/silent-hill-3/src/Event/stage/amusement_01.c
+++ b/silent-hill-3/src/Event/stage/amusement_01.c
@@ -370,7 +370,7 @@ void func_01F6E2A0_amusement_01(void) {
             func_01F70750_amusement_01();
 
             // spikes falling noise
-            SeCall(0x3BCA, 0.0f, 1.0f);
+            SeCall(15306, 0.0f, 1.0f);
             /* fallthrough */
 
         case 1:
@@ -459,7 +459,7 @@ void func_01F6E2A0_amusement_01(void) {
 
             func_001C2B80(1, &matrix);
             D_01F74DC0_amusement_01 = matrix[3][1];
-            D_01F74D88_amusement_01 = SeCall(0x3BCB, 0.0f, 1.0f);
+            D_01F74D88_amusement_01 = SeCall(15307, 0.0f, 1.0f);
             /* fallthrough */
 
         case 5:
@@ -960,7 +960,7 @@ int func_01F6FC80_amusement_01(void) {
             D_01F74C88_amusement_01 = 2;
             D_1D3169C |= 0x8000;
             ItemGet(0x46U);
-            SeCall(0x2B21, 0.0f, 1.0f);
+            SeCall(11041, 0.0f, 1.0f);
             func_00317490(0x46, 0.2f);
         case 2:
             if (func_0016C1C0(0xBF) == 0) {
@@ -994,7 +994,7 @@ int func_01F6FDC0_amusement_01(void) {
             D_01F74C88_amusement_01 = 2;
             D_1D3169C |= 0x10000;
             ItemGet(0x47U);
-            SeCall(0x2B21, 0.0f, 1.0f);
+            SeCall(11041, 0.0f, 1.0f);
             func_00317490(0x47, 0.2f);
             /* fallthrough */
         case 2:
@@ -1030,7 +1030,7 @@ int func_01F6FED0_amusement_01(void) {
         if (func_001C2580(2) == 0) {
             return 0;
         }
-        SeCall(0x3BC4, 0.0f, 1.0f);
+        SeCall(15300, 0.0f, 1.0f);
         D_01F74C88_amusement_01 = 2;
         func_001C2290(5, 0.8f);
     case 2:
@@ -1103,9 +1103,9 @@ int func_01F701B0_amusement_01(void) {
         case 0:
             func_00190A20(2);
             D_1D3169C |= 0x100000;
-            SeCall(0x3BC5, 0.0f, 1.0f);
+            SeCall(15301, 0.0f, 1.0f);
             if (GET_BIT(D_1D3169C, 0x15)) {
-                SeCall(0x4A3B, 0.0f, 1.0f);
+                SeCall(19003, 0.0f, 1.0f);
             }
             D_01F74C88_amusement_01++;
             /* fallthrough */
@@ -1130,9 +1130,9 @@ int func_01F702A0_amusement_01(void) {
         case 0:
             func_00190A20(2);
             D_1D3169C |= 0x200000;
-            SeCall(0x3BC5, 0.0f, 1.0f);
+            SeCall(15301, 0.0f, 1.0f);
             if (GET_BIT(D_1D3169C, 0x14)) {
-                SeCall(0x4A3B, 0.0f, 1.0f);
+                SeCall(19003, 0.0f, 1.0f);
             }
             D_01F74C88_amusement_01++;
             /* fallthrough */

--- a/silent-hill-3/src/Event/stage/amusement_01.h
+++ b/silent-hill-3/src/Event/stage/amusement_01.h
@@ -121,7 +121,7 @@ extern u_char GetActionLevel(void);
 extern int D_01F713D0_amusement_01;
 extern u_int D_1D3169C;
 
-extern int SeCall(float, float, int);
+extern int SeCall(int, float, float);
 
 extern int RoomName(void);
 extern void func_001C2A60(int, float);
@@ -298,9 +298,9 @@ void blood_candle_amusement_01(float a0, float a1) {    \
     sceVu0FVECTOR sp10;                                 \
     do {                                                \
         do {                                            \
-            SeCall(a0, 0.0f, 666);                      \
-            SeCall(a1, 0.0f, 666);                      \
-            SeCall(a1, 0.0f, 666);                      \
+            SeCall(666, 0.0f, a0);                      \
+            SeCall(666, 0.0f, a1);                      \
+            SeCall(666, 0.0f, a1);                      \
         } while(1);                                     \
     } while (0);                                        \
 }

--- a/silent-hill-3/src/Event/stage/amusement_01.h
+++ b/silent-hill-3/src/Event/stage/amusement_01.h
@@ -293,16 +293,16 @@ extern float D_01F74CF0_amusement_01;
 
 // @hack thanks `func_0015DCD0` :')
 /* begin candles, holy rituals to bend float arguments to our will */
-#define UNCURSE_AMUSEMENT_BLOOD()                       \
-void blood_candle_amusement_01(float a0, float a1) {    \
-    sceVu0FVECTOR sp10;                                 \
-    do {                                                \
-        do {                                            \
-            SeCall(666, 0.0f, a0);                      \
-            SeCall(666, 0.0f, a1);                      \
-            SeCall(666, 0.0f, a1);                      \
-        } while(1);                                     \
-    } while (0);                                        \
+#define UNCURSE_AMUSEMENT_BLOOD()                         \
+void blood_candle_amusement_01(float a0, float a1) {      \
+    sceVu0FVECTOR sp10;                                   \
+    do {                                                  \
+        do {                                              \
+            SeCall(a0, 0.0f, 666);                        \
+            SeCall(a1, 0.0f, 666);                        \
+            SeCall(a1, 0.0f, 666);                        \
+        } while(1);                                       \
+    } while (0);                                          \
 }
 
 #define UNCURSE_AMUSEMENT_MOON()                          \

--- a/silent-hill-3/src/Event/stage/amusement_02.c
+++ b/silent-hill-3/src/Event/stage/amusement_02.c
@@ -206,7 +206,7 @@ void func_01F6E050_amusement_02() {
 
     switch (RoomName()) {
         case 0xEA:
-            SeCall(1.0f, 0.0f, 0x4A48);
+            SeCall(0x4A48, 0.0f, 1.0f);
             return;
         default:
             return;

--- a/silent-hill-3/src/Event/stage/amusement_02.c
+++ b/silent-hill-3/src/Event/stage/amusement_02.c
@@ -206,7 +206,7 @@ void func_01F6E050_amusement_02() {
 
     switch (RoomName()) {
         case 0xEA:
-            SeCall(0x4A48, 0.0f, 1.0f);
+            SeCall(19016, 0.0f, 1.0f);
             return;
         default:
             return;

--- a/silent-hill-3/src/Event/stage/amusement_02.h
+++ b/silent-hill-3/src/Event/stage/amusement_02.h
@@ -42,7 +42,7 @@ void func_001E22F0(int, int, int);
 void func_002FE570(void);
 void func_00316C50(int);
 int func_01F6F560_amusement_02(int);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 
 extern Entry_01F763C0 D_01F763C0_amusement_02[];
 

--- a/silent-hill-3/src/Event/stage/building_b_00.c
+++ b/silent-hill-3/src/Event/stage/building_b_00.c
@@ -24,7 +24,7 @@ int func_01F6D9B0_building_b_00(void) {
             }
             func_00317490(0x3A, 0.2f);
             func_0016C3C0();
-            SeCall(0x2B21, 0.0f, 1.0f);
+            SeCall(11041, 0.0f, 1.0f);
             ItemGet(0x3A);
             D_1D31670[0] |= 0x1000;
             D_01F6FB00_building_b_00 += 1;
@@ -61,7 +61,7 @@ int func_01F6E0B0_building_b_00(void) { // same elevator bullshit as the others 
         D_1D31670[0] |= 0x400000;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     D_01F6FB10_building_b_00 += shGetDT();
     switch (D_01F6FB08_building_b_00) {
@@ -70,7 +70,7 @@ int func_01F6E0B0_building_b_00(void) { // same elevator bullshit as the others 
             if (D_01F6FB10_building_b_00 < 0.5f) {
                 return 0;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F6FB08_building_b_00 += 1;
         
         case 1:

--- a/silent-hill-3/src/Event/stage/building_b_00.c
+++ b/silent-hill-3/src/Event/stage/building_b_00.c
@@ -4,6 +4,7 @@ INCLUDE_ASM("asm/nonmatchings/Event/stage/building_b_00", func_01F6D680_building
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/building_b_00", func_01F6D7C0_building_b_00);
 
+#ifdef HOLY_CANDLE
 int func_01F6D9B0_building_b_00(void) {
     if (!GET_FLAG(D_1D31670, 0xB)) {
         func_00317420(0x3A);
@@ -23,7 +24,7 @@ int func_01F6D9B0_building_b_00(void) {
             }
             func_00317490(0x3A, 0.2f);
             func_0016C3C0();
-            SeCall(1.0f, 0.0f, 0x2B21);
+            SeCall(0x2B21, 0.0f, 1.0f);
             ItemGet(0x3A);
             D_1D31670[0] |= 0x1000;
             D_01F6FB00_building_b_00 += 1;
@@ -38,6 +39,9 @@ int func_01F6D9B0_building_b_00(void) {
     func_00190A20(0);
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/building_b_00", func_01F6D9B0_building_b_00);
+#endif
 
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/building_b_00", func_01F6DB00_building_b_00);
@@ -46,6 +50,7 @@ INCLUDE_ASM("asm/nonmatchings/Event/stage/building_b_00", func_01F6DC40_building
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/building_b_00", func_01F6DD70_building_b_00);
 
+#ifdef HOLY_CANDLE
 int func_01F6E0B0_building_b_00(void) { // same elevator bullshit as the others similar functions
     int var_s0;
 
@@ -56,7 +61,7 @@ int func_01F6E0B0_building_b_00(void) { // same elevator bullshit as the others 
         D_1D31670[0] |= 0x400000;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     D_01F6FB10_building_b_00 += shGetDT();
     switch (D_01F6FB08_building_b_00) {
@@ -65,7 +70,7 @@ int func_01F6E0B0_building_b_00(void) { // same elevator bullshit as the others 
             if (D_01F6FB10_building_b_00 < 0.5f) {
                 return 0;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F6FB08_building_b_00 += 1;
         
         case 1:
@@ -86,6 +91,9 @@ int func_01F6E0B0_building_b_00(void) { // same elevator bullshit as the others 
     }
     return var_s0;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/building_b_00", func_01F6E0B0_building_b_00);
+#endif
 
 
 void func_01F6E270_building_b_00(void) {

--- a/silent-hill-3/src/Event/stage/building_b_00.h
+++ b/silent-hill-3/src/Event/stage/building_b_00.h
@@ -9,7 +9,7 @@
 #define BUILDING_OTHERWORLD_1F_LAST_FAIRY_TAIL_PIECE_ROOM 0x81
 
 int RoomName(void);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 int func_00168440(void);
 void func_0016C1A0(void);
 void func_0016C1B0(void);

--- a/silent-hill-3/src/Event/stage/building_b_02.c
+++ b/silent-hill-3/src/Event/stage/building_b_02.c
@@ -44,6 +44,7 @@ void func_01F6DB60_building_b_02(void) { //I will debug it later
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/building_b_02", func_01F6DC70_building_b_02);
 
+#ifdef HOLY_CANDLE
 int func_01F6DE10_building_b_02(void) { //this is similar to func_01F6E700_building_b_03
     int var_s0;
 
@@ -55,7 +56,7 @@ int func_01F6DE10_building_b_02(void) { //this is similar to func_01F6E700_build
         D_1D31670 |= 0x400000;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     D_01F6EF08_building_b_02 += shGetDT();
 
@@ -65,7 +66,7 @@ int func_01F6DE10_building_b_02(void) { //this is similar to func_01F6E700_build
             if (D_01F6EF08_building_b_02 < 0.5f) {
                 return 0;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F6EF00_building_b_02 += 1;
         
         case 1:
@@ -86,6 +87,9 @@ int func_01F6DE10_building_b_02(void) { //this is similar to func_01F6E700_build
     }
     return var_s0;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/building_b_02", func_01F6DE10_building_b_02);
+#endif
 
 void func_01F6DFD0_building_b_02(void) {
     

--- a/silent-hill-3/src/Event/stage/building_b_02.c
+++ b/silent-hill-3/src/Event/stage/building_b_02.c
@@ -56,7 +56,7 @@ int func_01F6DE10_building_b_02(void) { //this is similar to func_01F6E700_build
         D_1D31670 |= 0x400000;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     D_01F6EF08_building_b_02 += shGetDT();
 
@@ -66,7 +66,7 @@ int func_01F6DE10_building_b_02(void) { //this is similar to func_01F6E700_build
             if (D_01F6EF08_building_b_02 < 0.5f) {
                 return 0;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F6EF00_building_b_02 += 1;
         
         case 1:

--- a/silent-hill-3/src/Event/stage/building_b_02.h
+++ b/silent-hill-3/src/Event/stage/building_b_02.h
@@ -12,7 +12,7 @@
 #define BUILDING_OTHERWORLD_4F_SILVER_COIN_ROOM 0x8D
 
 int RoomName(void);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 float shGetDT(void);
 void func_0016C1A0(void);
 void func_0016C1B0(void);

--- a/silent-hill-3/src/Event/stage/building_b_03.c
+++ b/silent-hill-3/src/Event/stage/building_b_03.c
@@ -58,7 +58,7 @@ int func_01F6E700_building_b_03(void) {
         D_1D31670[0] |= 0x400000; 
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     D_01F6FC08_building_b_03 += shGetDT();
     switch (D_01F6FC00_building_b_03) {
@@ -66,7 +66,7 @@ int func_01F6E700_building_b_03(void) {
             if (D_01F6FC08_building_b_03 < 0.5f) {
                 return 0;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F6FC00_building_b_03 += 1;
         case 1:
             if (D_01F6FC08_building_b_03 < 1.5f) {

--- a/silent-hill-3/src/Event/stage/building_b_03.c
+++ b/silent-hill-3/src/Event/stage/building_b_03.c
@@ -58,7 +58,7 @@ int func_01F6E700_building_b_03(void) {
         D_1D31670[0] |= 0x400000; 
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     D_01F6FC08_building_b_03 += shGetDT();
     switch (D_01F6FC00_building_b_03) {
@@ -66,7 +66,7 @@ int func_01F6E700_building_b_03(void) {
             if (D_01F6FC08_building_b_03 < 0.5f) {
                 return 0;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F6FC00_building_b_03 += 1;
         case 1:
             if (D_01F6FC08_building_b_03 < 1.5f) {

--- a/silent-hill-3/src/Event/stage/building_b_03.h
+++ b/silent-hill-3/src/Event/stage/building_b_03.h
@@ -8,7 +8,7 @@
 #define BUILDING_OTHERWORLD_ELEVATOR       0x93
 
 int RoomName(void);
-void SeCall(float, float, int);
+void SeCall(int, float, float);
 float shGetDT(void);
 void func_0016C1A0(void);
 void func_0016C1B0(void);

--- a/silent-hill-3/src/Event/stage/church_00.c
+++ b/silent-hill-3/src/Event/stage/church_00.c
@@ -67,7 +67,7 @@ int func_01F6D680_church_00(void)
             if (func_001646C0() != 0) {
                 s0 = 1;
             } else {
-                SeCall(0x4A38, 0.0f, 1.0f);
+                SeCall(19000, 0.0f, 1.0f);
             }
             D_01F6E600_church_00++;
             func_0019A940();
@@ -80,7 +80,7 @@ int func_01F6D680_church_00(void)
         }
         D_01F6E600_church_00++;
         func_0019A940();
-        SeCall(0x4A39, 0.0f, 1.0f);
+        SeCall(19001, 0.0f, 1.0f);
 
     case 3:
         if (func_0019A9B0(3.0f) != 0) {

--- a/silent-hill-3/src/Event/stage/church_00.c
+++ b/silent-hill-3/src/Event/stage/church_00.c
@@ -3,6 +3,7 @@
 
 UNCURSE_CHURCH();
 
+#ifdef HOLY_CANDLE
 int func_01F6D680_church_00(void)
 {
     int s0 = 0;
@@ -66,7 +67,7 @@ int func_01F6D680_church_00(void)
             if (func_001646C0() != 0) {
                 s0 = 1;
             } else {
-                SeCall(1.0f, 0.0f, 0x4A38);
+                SeCall(0x4A38, 0.0f, 1.0f);
             }
             D_01F6E600_church_00++;
             func_0019A940();
@@ -79,7 +80,7 @@ int func_01F6D680_church_00(void)
         }
         D_01F6E600_church_00++;
         func_0019A940();
-        SeCall(1.0f, 0.0f, 0x4A39);
+        SeCall(0x4A39, 0.0f, 1.0f);
 
     case 3:
         if (func_0019A9B0(3.0f) != 0) {
@@ -97,6 +98,9 @@ int func_01F6D680_church_00(void)
 
     return s0;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/church_00", func_01F6D680_church_00);
+#endif
 
 int func_01F6D9C0_church_00(int arg0) {
 

--- a/silent-hill-3/src/Event/stage/church_00.h
+++ b/silent-hill-3/src/Event/stage/church_00.h
@@ -30,7 +30,7 @@ int func_001C2580(int);
 void func_00300390(void);
 void func_00316C50(int);
 void func_01F6DCF0_church_00(Q*, int*, Q*, int*, int*);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 float shGetDT(void);
 
 extern short D_01F6E550_church_00[];
@@ -61,11 +61,11 @@ void uncurse(float a0, float a1, float a2, float a3, u_int a4, void* a5) { \
     float x;                                                               \
     float y;                                                               \
     do {                                                                   \
-        SeCall(1.0f, 0.0f, 19000);                                         \
+        SeCall(19000, 0.0f, 1.0f);                                         \
         do {                                                               \
-            SeCall(a0, 0.0f, 19000);                                       \
-            SeCall(a1, 0.0f, 19000);                                       \
-            SeCall(a1, 0.0f, 19000);                                       \
+            SeCall(19000, 0.0f, a0);                                       \
+            SeCall(19000, 0.0f, a1);                                       \
+            SeCall(19000, 0.0f, a1);                                       \
         } while(1);                                                        \
     } while (0);                                                           \
 }

--- a/silent-hill-3/src/Event/stage/church_02.c
+++ b/silent-hill-3/src/Event/stage/church_02.c
@@ -34,7 +34,7 @@ int func_01F6D7B0_church_02(void) {
         case 0:
             D_1D316AC[0] |= 0x20000000;
             func_00190A20(2);
-            SeCall(1.0f, 0.0f, 0x2B21);
+            SeCall(0x2B21, 0.0f, 1.0f);
             D_1D316A4[0] |= 0x02000000;
             ItemGet(0x4B);
             func_00317490(0x4B, 0.2f);
@@ -52,14 +52,14 @@ int func_01F6D7B0_church_02(void) {
             if (func_001C2580(2) == 0) {
                 return 0;
             }
-            SeCall(0.5f, 0.0f, 0x4A38);
+            SeCall(0x4A38, 0.0f, 0.5f);
             func_0019A940();
             D_01F77580_church_02++;
         case 3:
             if (func_0019A9B0(1.2f) == 0) {
                 return 0;
             }
-            SeCall(0.5f, 0.0f, 0x4A39);
+            SeCall(0x4A39, 0.0f, 0.5f);
             D_01F77580_church_02++;
         case 4:
             if (func_0016C540(&D_01F76A40_church_02, &D_01F76AA0_church_02) == 0) {
@@ -69,7 +69,7 @@ int func_01F6D7B0_church_02(void) {
             if (func_001646C0() != 0) {
                 D_01F77580_church_02 += 2;
             } else {
-                SeCall(0.5f, 0.0f, 0x4A38);
+                SeCall(0x4A38, 0.0f, 0.5f);
             }
             func_0019A940();
             D_01F77580_church_02++;
@@ -77,7 +77,7 @@ int func_01F6D7B0_church_02(void) {
             if (func_0019A9B0(1.2f) == 0) {
                 return 0;
             }
-            SeCall(0.5f, 0.0f, 0x4A39);
+            SeCall(0x4A39, 0.0f, 0.5f);
             D_01F77580_church_02++;
             func_0019A940();
         case 6:
@@ -86,7 +86,7 @@ int func_01F6D7B0_church_02(void) {
             }
             D_01F77580_church_02++;
         case 7:
-            SeCall(1.0f, 0.0f, 0x2B21);
+            SeCall(0x2B21, 0.0f, 1.0f);
             func_001C2290(5, 1.2f);
             D_1D316A4[0] |= 0x04000000;
             ItemGet(0x4C);

--- a/silent-hill-3/src/Event/stage/church_02.c
+++ b/silent-hill-3/src/Event/stage/church_02.c
@@ -34,7 +34,7 @@ int func_01F6D7B0_church_02(void) {
         case 0:
             D_1D316AC[0] |= 0x20000000;
             func_00190A20(2);
-            SeCall(0x2B21, 0.0f, 1.0f);
+            SeCall(11041, 0.0f, 1.0f);
             D_1D316A4[0] |= 0x02000000;
             ItemGet(0x4B);
             func_00317490(0x4B, 0.2f);
@@ -52,14 +52,14 @@ int func_01F6D7B0_church_02(void) {
             if (func_001C2580(2) == 0) {
                 return 0;
             }
-            SeCall(0x4A38, 0.0f, 0.5f);
+            SeCall(19000, 0.0f, 0.5f);
             func_0019A940();
             D_01F77580_church_02++;
         case 3:
             if (func_0019A9B0(1.2f) == 0) {
                 return 0;
             }
-            SeCall(0x4A39, 0.0f, 0.5f);
+            SeCall(19001, 0.0f, 0.5f);
             D_01F77580_church_02++;
         case 4:
             if (func_0016C540(&D_01F76A40_church_02, &D_01F76AA0_church_02) == 0) {
@@ -69,7 +69,7 @@ int func_01F6D7B0_church_02(void) {
             if (func_001646C0() != 0) {
                 D_01F77580_church_02 += 2;
             } else {
-                SeCall(0x4A38, 0.0f, 0.5f);
+                SeCall(19000, 0.0f, 0.5f);
             }
             func_0019A940();
             D_01F77580_church_02++;
@@ -77,7 +77,7 @@ int func_01F6D7B0_church_02(void) {
             if (func_0019A9B0(1.2f) == 0) {
                 return 0;
             }
-            SeCall(0x4A39, 0.0f, 0.5f);
+            SeCall(19001, 0.0f, 0.5f);
             D_01F77580_church_02++;
             func_0019A940();
         case 6:
@@ -86,7 +86,7 @@ int func_01F6D7B0_church_02(void) {
             }
             D_01F77580_church_02++;
         case 7:
-            SeCall(0x2B21, 0.0f, 1.0f);
+            SeCall(11041, 0.0f, 1.0f);
             func_001C2290(5, 1.2f);
             D_1D316A4[0] |= 0x04000000;
             ItemGet(0x4C);

--- a/silent-hill-3/src/Event/stage/church_02.h
+++ b/silent-hill-3/src/Event/stage/church_02.h
@@ -24,7 +24,7 @@ void func_0012CFE0(int);
 void func_0029F330(float*, float*);
 int func_002A47C0(float, float);
 void ItemGet(u_int);
-void SeCall(float, float, int);
+void SeCall(int, float, float);
 int func_001646C0(void);
 void func_0016C9C0(void);
 void func_0019A940(void);

--- a/silent-hill-3/src/Event/stage/construct_00.c
+++ b/silent-hill-3/src/Event/stage/construct_00.c
@@ -3,6 +3,7 @@
 
 UNCURSE_CONSTRUCT_STAR();
 
+#ifdef HOLY_CANDLE
 int func_01F6D680_construct_00(void) {
     int ret;
 
@@ -10,7 +11,7 @@ int func_01F6D680_construct_00(void) {
         case 0:
             func_00190A20(2);
         
-            SeCall(1.0f, 0.0f, 0x32CA); // I hate you SeCall
+            SeCall(0x32CA, 0.0f, 1.0f); // I hate you SeCall
         
             func_0013D250(0, &D_01F6F8B0_construct_00, 1.0f);
             D_01F6FA38_construct_00 = 0.0f;
@@ -36,11 +37,15 @@ int func_01F6D680_construct_00(void) {
 
     return ret;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/construct_00", func_01F6D680_construct_00);
+#endif
 
 #pragma supress_warnings on
 UNCURSE_CONSTRUCT_MOON();
 #pragma supress_warnings off
 
+#ifdef HOLY_CANDLE
 int func_01F6D7E0_construct_00(void) { //check 3th floor sign
     float volume, zero;
 
@@ -58,7 +63,7 @@ int func_01F6D7E0_construct_00(void) { //check 3th floor sign
             D_01F6FA00_construct_00 += 1;
             func_0016C3C0();
     
-            SeCall(1.0f, 0.0f, 0x4A52);
+            SeCall(0x4A52, 0.0f, 1.0f);
         default:
             if (func_0016C1C0(3) == 0) {
                 return 0;
@@ -68,7 +73,11 @@ int func_01F6D7E0_construct_00(void) { //check 3th floor sign
             return 1;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/construct_00", func_01F6D7E0_construct_00);
+#endif
 
+#ifdef HOLY_CANDLE
 int func_01F6D8D0_construct_00(void) { //check 4th floor
     if (!GET_FLAG(D_1D31668, 1)) { 
         D_01F6FA08_construct_00 = 0;
@@ -84,7 +93,7 @@ int func_01F6D8D0_construct_00(void) { //check 4th floor
             }
             D_01F6FA08_construct_00 += 1;
             func_0016C3C0();
-            SeCall(1.0f, 0.0f, 0x4A52);
+            SeCall(0x4A52, 0.0f, 1.0f);
         
         default:
             if (func_0016C1C0(3) == 0) {
@@ -95,7 +104,11 @@ int func_01F6D8D0_construct_00(void) { //check 4th floor
             return 1;    
     }  
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/construct_00", func_01F6D8D0_construct_00);
+#endif
 
+#ifdef HOLY_CANDLE
 int func_01F6D9C0_construct_00(void) {
     float var_f12;
     float var_f12_2;
@@ -126,7 +139,7 @@ int func_01F6D9C0_construct_00(void) {
                 if (func_001C2580(2) == 0) {
                     return 0;
                 }
-                SeCall(1.0f, 0.0f, 0x32C8);
+                SeCall(0x32C8, 0.0f, 1.0f);
                 D_01F6FA30_construct_00 = 2;
                 
             default:
@@ -149,7 +162,11 @@ int func_01F6D9C0_construct_00(void) {
         return 1;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/construct_00", func_01F6D9C0_construct_00);
+#endif
 
+#ifdef HOLY_CANDLE
 int func_01F6DBC0_construct_00(void) {
     int var_s0;
     var_s0 = 0;
@@ -168,7 +185,7 @@ int func_01F6DBC0_construct_00(void) {
                 return 0;
             }
             func_00317490(0x18, 0.2f);
-            SeCall(1.0f, 0.0f, 0x2B21);
+            SeCall(0x2B21, 0.0f, 1.0f);
             D_1D31664[0] |= 0x10000000;
             D_01F6FA20_construct_00 = 2;
     
@@ -196,7 +213,11 @@ int func_01F6DBC0_construct_00(void) {
     }
     return var_s0;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/construct_00", func_01F6DBC0_construct_00);
+#endif
 
+#ifdef HOLY_CANDLE
 int func_01F6DD90_construct_00(void) {
     sceVu0FVECTOR sp20;
     sceVu0FVECTOR sp10;
@@ -232,7 +253,7 @@ int func_01F6DD90_construct_00(void) {
             }
             
             func_00190000(&sp20, sp20[5]);
-            SeCall(1.0f, 0.0f, 0x32C9);
+            SeCall(0x32C9, 0.0f, 1.0f);
             D_01F6FA18_construct_00 += 1;
         
     }
@@ -253,6 +274,9 @@ int func_01F6DD90_construct_00(void) {
     D_1D31664[0] &= 0xBFFFFFFF;
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/construct_00", func_01F6DD90_construct_00);
+#endif
 
 void func_01F6DFB0_construct_00(void) {
     float temp_f1;

--- a/silent-hill-3/src/Event/stage/construct_00.c
+++ b/silent-hill-3/src/Event/stage/construct_00.c
@@ -11,7 +11,7 @@ int func_01F6D680_construct_00(void) {
         case 0:
             func_00190A20(2);
         
-            SeCall(0x32CA, 0.0f, 1.0f); // I hate you SeCall
+            SeCall(13002, 0.0f, 1.0f); // I hate you SeCall
         
             func_0013D250(0, &D_01F6F8B0_construct_00, 1.0f);
             D_01F6FA38_construct_00 = 0.0f;
@@ -63,7 +63,7 @@ int func_01F6D7E0_construct_00(void) { //check 3th floor sign
             D_01F6FA00_construct_00 += 1;
             func_0016C3C0();
     
-            SeCall(0x4A52, 0.0f, 1.0f);
+            SeCall(19026, 0.0f, 1.0f);
         default:
             if (func_0016C1C0(3) == 0) {
                 return 0;
@@ -93,7 +93,7 @@ int func_01F6D8D0_construct_00(void) { //check 4th floor
             }
             D_01F6FA08_construct_00 += 1;
             func_0016C3C0();
-            SeCall(0x4A52, 0.0f, 1.0f);
+            SeCall(19026, 0.0f, 1.0f);
         
         default:
             if (func_0016C1C0(3) == 0) {
@@ -139,7 +139,7 @@ int func_01F6D9C0_construct_00(void) {
                 if (func_001C2580(2) == 0) {
                     return 0;
                 }
-                SeCall(0x32C8, 0.0f, 1.0f);
+                SeCall(13000, 0.0f, 1.0f);
                 D_01F6FA30_construct_00 = 2;
                 
             default:
@@ -185,7 +185,7 @@ int func_01F6DBC0_construct_00(void) {
                 return 0;
             }
             func_00317490(0x18, 0.2f);
-            SeCall(0x2B21, 0.0f, 1.0f);
+            SeCall(11041, 0.0f, 1.0f);
             D_1D31664[0] |= 0x10000000;
             D_01F6FA20_construct_00 = 2;
     
@@ -253,7 +253,7 @@ int func_01F6DD90_construct_00(void) {
             }
             
             func_00190000(&sp20, sp20[5]);
-            SeCall(0x32C9, 0.0f, 1.0f);
+            SeCall(13001, 0.0f, 1.0f);
             D_01F6FA18_construct_00 += 1;
         
     }

--- a/silent-hill-3/src/Event/stage/construct_00.h
+++ b/silent-hill-3/src/Event/stage/construct_00.h
@@ -9,7 +9,7 @@ int func_0016C540(int*, int*);
 int func_00190A20(int);
 void func_001C2290(int, float);
 float shGetDT(void);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 int func_0016C1C0(int);
 void func_0016C3C0(void);
 int func_00190C00(void);

--- a/silent-hill-3/src/Event/stage/hospital_b_00.c
+++ b/silent-hill-3/src/Event/stage/hospital_b_00.c
@@ -420,7 +420,7 @@ int func_01F6E6C0_hospital_b_00(void) {
         D_01F70608_hospital_b_00 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     D_01F70608_hospital_b_00 += shGetDT();
     switch (D_01F70600_hospital_b_00) {    
@@ -428,7 +428,7 @@ int func_01F6E6C0_hospital_b_00(void) {
             if (D_01F70608_hospital_b_00 < 0.5f) {
                 return 0;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F70600_hospital_b_00++;
         case 1:
             if (D_01F70608_hospital_b_00 < 1.5f) {

--- a/silent-hill-3/src/Event/stage/hospital_b_00.c
+++ b/silent-hill-3/src/Event/stage/hospital_b_00.c
@@ -409,6 +409,7 @@ void func_01F6E5B0_hospital_b_00(void) {
     }
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6E6C0_hospital_b_00(void) {
     int ret;
     
@@ -419,7 +420,7 @@ int func_01F6E6C0_hospital_b_00(void) {
         D_01F70608_hospital_b_00 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     D_01F70608_hospital_b_00 += shGetDT();
     switch (D_01F70600_hospital_b_00) {    
@@ -427,7 +428,7 @@ int func_01F6E6C0_hospital_b_00(void) {
             if (D_01F70608_hospital_b_00 < 0.5f) {
                 return 0;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F70600_hospital_b_00++;
         case 1:
             if (D_01F70608_hospital_b_00 < 1.5f) {
@@ -445,6 +446,9 @@ int func_01F6E6C0_hospital_b_00(void) {
         }
     return ret;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_00", func_01F6E6C0_hospital_b_00);
+#endif
 
 void func_01F6E880_hospital_b_00(void) {
 

--- a/silent-hill-3/src/Event/stage/hospital_b_00.h
+++ b/silent-hill-3/src/Event/stage/hospital_b_00.h
@@ -91,7 +91,7 @@ int func_0016B4E0(void*);
 int RoomName(void);
 u_char GetActionLevel(void);
 int GetItemCount(int);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 float shGetDT(void);
 void clAddDynamicWall(int*);
 void clAddDynamicFloor(int*);

--- a/silent-hill-3/src/Event/stage/hospital_b_01.c
+++ b/silent-hill-3/src/Event/stage/hospital_b_01.c
@@ -54,12 +54,17 @@ int func_01F6D7A0_hospital_b_01(void) {
     }
 }
 
+#ifdef HOLY_CANDLE
 void func_01F6D970_hospital_b_01(void) {
     func_001433A0(shCharacterGetSubCharacter(0x101C, 0x146), 0x2728, 0);
     D_1D31698 |= 0x200;
-    SeCall(1.0f, 0.0f, 0x3A99);
+    SeCall(0x3A99, 0.0f, 1.0f);
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_01", func_01F6D970_hospital_b_01);
+#endif
 
+#ifdef HOLY_CANDLE
 int func_01F6D9D0_hospital_b_01(void) {
     int ret;
 
@@ -70,7 +75,7 @@ int func_01F6D9D0_hospital_b_01(void) {
         D_01F6EB88_hospital_b_01 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     D_01F6EB88_hospital_b_01 += shGetDT();
     switch (D_01F6EB80_hospital_b_01) {
@@ -78,7 +83,7 @@ int func_01F6D9D0_hospital_b_01(void) {
             if (D_01F6EB88_hospital_b_01 < 0.5f) {
                 return 0;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F6EB80_hospital_b_01 += 1;
         case 1:
             if (D_01F6EB88_hospital_b_01 < 1.5f) {
@@ -96,6 +101,9 @@ int func_01F6D9D0_hospital_b_01(void) {
     }
     return ret;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_01", func_01F6D9D0_hospital_b_01);
+#endif
 
 void func_01F6DB80_hospital_b_01(void) {
 

--- a/silent-hill-3/src/Event/stage/hospital_b_01.c
+++ b/silent-hill-3/src/Event/stage/hospital_b_01.c
@@ -58,7 +58,7 @@ int func_01F6D7A0_hospital_b_01(void) {
 void func_01F6D970_hospital_b_01(void) {
     func_001433A0(shCharacterGetSubCharacter(0x101C, 0x146), 0x2728, 0);
     D_1D31698 |= 0x200;
-    SeCall(0x3A99, 0.0f, 1.0f);
+    SeCall(15001, 0.0f, 1.0f);
 }
 #else
 INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_01", func_01F6D970_hospital_b_01);
@@ -75,7 +75,7 @@ int func_01F6D9D0_hospital_b_01(void) {
         D_01F6EB88_hospital_b_01 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     D_01F6EB88_hospital_b_01 += shGetDT();
     switch (D_01F6EB80_hospital_b_01) {
@@ -83,7 +83,7 @@ int func_01F6D9D0_hospital_b_01(void) {
             if (D_01F6EB88_hospital_b_01 < 0.5f) {
                 return 0;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F6EB80_hospital_b_01 += 1;
         case 1:
             if (D_01F6EB88_hospital_b_01 < 1.5f) {

--- a/silent-hill-3/src/Event/stage/hospital_b_01.h
+++ b/silent-hill-3/src/Event/stage/hospital_b_01.h
@@ -27,7 +27,7 @@ void func_01F6D740_hospital_b_01();
 void func_01F6D970_hospital_b_01();
 void func_01F6DC60_hospital_b_01();
 int RoomName(void);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 float shGetDT(void);
 
 extern Vector4 D_01F6EBB0_hospital_b_01;

--- a/silent-hill-3/src/Event/stage/hospital_b_02.c
+++ b/silent-hill-3/src/Event/stage/hospital_b_02.c
@@ -70,7 +70,7 @@ int func_01F6E5E0_hospital_b_02(unk_01F6E700_hospital_b_02_struct* arg0) {
     PlayerResultTimerCountUp();
     func_0029FA30();
     if (arg0->unk8AC == arg0->unk8A8) {
-        SeCall(0x3AFF, 0.0f, 1.0f);
+        SeCall(15103, 0.0f, 1.0f);
         return 2;
     }
     temp_s1 = func_01F6E4E0_hospital_b_02();
@@ -88,7 +88,7 @@ int func_01F6E5E0_hospital_b_02(unk_01F6E700_hospital_b_02_struct* arg0) {
             arg0->unk8AC &= ~(0xF << temp_t0);
             arg0->unk8AC |= a1;
             arg0->unk8A4 = 0.2f;
-            SeCall(0x3AFC, 0.0f, 1.0f);
+            SeCall(15100, 0.0f, 1.0f);
         }
     }
     return 0;
@@ -228,7 +228,7 @@ int func_01F6F780_hospital_b_02(void) {
         D_01F74108_hospital_b_02 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     D_01F74108_hospital_b_02 += shGetDT();
     switch (D_01F74100_hospital_b_02) {
@@ -236,7 +236,7 @@ int func_01F6F780_hospital_b_02(void) {
             if (D_01F74108_hospital_b_02 < 0.5f) {
                 return 0;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F74100_hospital_b_02 += 1;
         case 1:
             if (D_01F74108_hospital_b_02 < 1.5f) {
@@ -270,7 +270,7 @@ int func_01F6F930_hospital_b_02(void) {
         D_01F74118_hospital_b_02 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     D_01F74118_hospital_b_02 += shGetDT();
     switch (D_01F74110_hospital_b_02) {
@@ -278,7 +278,7 @@ int func_01F6F930_hospital_b_02(void) {
             if (D_01F74118_hospital_b_02 < 0.5f) {
                 return 0;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F74110_hospital_b_02 += 1;
         case 1:
             if (D_01F74118_hospital_b_02 < 1.5f) {
@@ -326,7 +326,7 @@ void func_01F6FBA0_hospital_b_02(void) {
         }
 
         if (var_f0 <= 1000.0f) {
-            SeCall(0x3B01, -0.7853982f, (1000.0f - var_f0) / 1000.0f);
+            SeCall(15105, -0.7853982f, (1000.0f - var_f0) / 1000.0f);
             D_01F74148_hospital_b_02 = 1;
         }    
     }    

--- a/silent-hill-3/src/Event/stage/hospital_b_02.c
+++ b/silent-hill-3/src/Event/stage/hospital_b_02.c
@@ -59,6 +59,7 @@ INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6E4C0_hospital
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6E4E0_hospital_b_02);
 
+#ifdef HOLY_CANDLE
 int func_01F6E5E0_hospital_b_02(unk_01F6E700_hospital_b_02_struct* arg0) {
     int temp_s1;
     int temp_t0;
@@ -69,7 +70,7 @@ int func_01F6E5E0_hospital_b_02(unk_01F6E700_hospital_b_02_struct* arg0) {
     PlayerResultTimerCountUp();
     func_0029FA30();
     if (arg0->unk8AC == arg0->unk8A8) {
-        SeCall(1.0f, 0.0f, 0x3AFF);
+        SeCall(0x3AFF, 0.0f, 1.0f);
         return 2;
     }
     temp_s1 = func_01F6E4E0_hospital_b_02();
@@ -87,11 +88,14 @@ int func_01F6E5E0_hospital_b_02(unk_01F6E700_hospital_b_02_struct* arg0) {
             arg0->unk8AC &= ~(0xF << temp_t0);
             arg0->unk8AC |= a1;
             arg0->unk8A4 = 0.2f;
-            SeCall(1.0f, 0.0f, 0x3AFC);
+            SeCall(0x3AFC, 0.0f, 1.0f);
         }
     }
     return 0;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6E5E0_hospital_b_02);
+#endif
 
 void func_01F6E700_hospital_b_02(unk_01F6E700_hospital_b_02_struct *arg0) {
     u_int *temp;
@@ -212,6 +216,7 @@ INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6EEB0_hospital
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6EFD0_hospital_b_02);
 
+#ifdef HOLY_CANDLE
 int func_01F6F780_hospital_b_02(void) {
     int ret;
 
@@ -223,7 +228,7 @@ int func_01F6F780_hospital_b_02(void) {
         D_01F74108_hospital_b_02 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     D_01F74108_hospital_b_02 += shGetDT();
     switch (D_01F74100_hospital_b_02) {
@@ -231,7 +236,7 @@ int func_01F6F780_hospital_b_02(void) {
             if (D_01F74108_hospital_b_02 < 0.5f) {
                 return 0;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F74100_hospital_b_02 += 1;
         case 1:
             if (D_01F74108_hospital_b_02 < 1.5f) {
@@ -250,7 +255,11 @@ int func_01F6F780_hospital_b_02(void) {
     }
     return ret;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6F780_hospital_b_02);
+#endif
 
+#ifdef HOLY_CANDLE
 int func_01F6F930_hospital_b_02(void) {
     int ret;
 
@@ -261,7 +270,7 @@ int func_01F6F930_hospital_b_02(void) {
         D_01F74118_hospital_b_02 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     D_01F74118_hospital_b_02 += shGetDT();
     switch (D_01F74110_hospital_b_02) {
@@ -269,7 +278,7 @@ int func_01F6F930_hospital_b_02(void) {
             if (D_01F74118_hospital_b_02 < 0.5f) {
                 return 0;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F74110_hospital_b_02 += 1;
         case 1:
             if (D_01F74118_hospital_b_02 < 1.5f) {
@@ -287,9 +296,13 @@ int func_01F6F930_hospital_b_02(void) {
     }
     return ret;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6F930_hospital_b_02);
+#endif
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6FAD0_hospital_b_02);
 
+#ifdef HOLY_CANDLE
 void func_01F6FBA0_hospital_b_02(void) {
     sceVu0FVECTOR sp20;
     float var_f0;
@@ -313,11 +326,14 @@ void func_01F6FBA0_hospital_b_02(void) {
         }
 
         if (var_f0 <= 1000.0f) {
-            SeCall((1000.0f - var_f0) / 1000.0f, -0.7853982f, 0x3B01);
+            SeCall(0x3B01, -0.7853982f, (1000.0f - var_f0) / 1000.0f);
             D_01F74148_hospital_b_02 = 1;
         }    
     }    
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6FBA0_hospital_b_02);
+#endif
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_b_02", func_01F6FCB0_hospital_b_02);
 

--- a/silent-hill-3/src/Event/stage/hospital_b_02.h
+++ b/silent-hill-3/src/Event/stage/hospital_b_02.h
@@ -25,7 +25,7 @@ int func_00190A20(int);
 void* func_00190AC0(void);
 int func_0013D080(int, int, int, int);
 int func_0016BED0(int, int);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 void PlayerResultTimerCountUp(void);
 void func_0029FA30(void);
 int GetRiddleLevel(void);

--- a/silent-hill-3/src/Event/stage/hospital_f_00.c
+++ b/silent-hill-3/src/Event/stage/hospital_f_00.c
@@ -326,7 +326,7 @@ int func_01F6E050_hospital_f_00(void) {
             if (func_0016C1C0(0x37) != 0) {
                 func_0016C3C0();
                 temp_s0->unkA8 = 5U;
-                SeCall(0x3840, 0.0f, 1.0f);
+                SeCall(14400, 0.0f, 1.0f);
             }
             break;
         case 5:
@@ -336,7 +336,7 @@ int func_01F6E050_hospital_f_00(void) {
             } else {
                 temp_s0->unkB0 = 0;
                 temp_s0->unkA8 = 6U;
-                SeCall(0x2B21, 0.0f, 1.0f);
+                SeCall(11041, 0.0f, 1.0f);
             }
             func_01F6E030_hospital_f_00(temp_s0);
             func_0016BC00(1);
@@ -415,7 +415,7 @@ int func_01F6E490_hospital_f_00(void) {
         D_01F6FA90_hospital_f_00 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     
     D_01F6FA90_hospital_f_00 += shGetDT();
@@ -426,7 +426,7 @@ int func_01F6E490_hospital_f_00(void) {
             if (D_01F6FA90_hospital_f_00 < 0.5f) {
                 return 0;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F6FA88_hospital_f_00 += 1;
         
         case 1:

--- a/silent-hill-3/src/Event/stage/hospital_f_00.c
+++ b/silent-hill-3/src/Event/stage/hospital_f_00.c
@@ -274,6 +274,7 @@ void func_01F6E030_hospital_f_00(PictureGroup *arg0) {
     func_001DE5B0(func_01F6DFF0_hospital_f_00, arg0, 1);
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6E050_hospital_f_00(void) {
     float var_f12;
     float var_f12_2;
@@ -325,7 +326,7 @@ int func_01F6E050_hospital_f_00(void) {
             if (func_0016C1C0(0x37) != 0) {
                 func_0016C3C0();
                 temp_s0->unkA8 = 5U;
-                SeCall(1.0f, 0.0f, 0x3840);
+                SeCall(0x3840, 0.0f, 1.0f);
             }
             break;
         case 5:
@@ -335,7 +336,7 @@ int func_01F6E050_hospital_f_00(void) {
             } else {
                 temp_s0->unkB0 = 0;
                 temp_s0->unkA8 = 6U;
-                SeCall(1.0f, 0.0f, 0x2B21);
+                SeCall(0x2B21, 0.0f, 1.0f);
             }
             func_01F6E030_hospital_f_00(temp_s0);
             func_0016BC00(1);
@@ -373,6 +374,9 @@ int func_01F6E050_hospital_f_00(void) {
     }
     return 0;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_f_00", func_01F6E050_hospital_f_00);
+#endif
 
 
 void func_01F6E3C0_hospital_f_00(void) {
@@ -399,6 +403,7 @@ void func_01F6E3C0_hospital_f_00(void) {
     }
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6E490_hospital_f_00(void) {
     int ret;
 
@@ -410,7 +415,7 @@ int func_01F6E490_hospital_f_00(void) {
         D_01F6FA90_hospital_f_00 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     
     D_01F6FA90_hospital_f_00 += shGetDT();
@@ -421,7 +426,7 @@ int func_01F6E490_hospital_f_00(void) {
             if (D_01F6FA90_hospital_f_00 < 0.5f) {
                 return 0;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F6FA88_hospital_f_00 += 1;
         
         case 1:
@@ -441,6 +446,9 @@ int func_01F6E490_hospital_f_00(void) {
     }
     return ret;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_f_00", func_01F6E490_hospital_f_00);
+#endif
 
 void func_01F6E640_hospital_f_00(void) {
 

--- a/silent-hill-3/src/Event/stage/hospital_f_00.h
+++ b/silent-hill-3/src/Event/stage/hospital_f_00.h
@@ -123,7 +123,7 @@ void func_00316C50(int);
 void PictureDraw(void*);
 void PictureLoadImage(void*);
 void shQzero(void*, int);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 
 void func_001DE5B0(void (*)(), PictureGroup*, int); // maybe this is the problem
 

--- a/silent-hill-3/src/Event/stage/hospital_f_01.c
+++ b/silent-hill-3/src/Event/stage/hospital_f_01.c
@@ -194,7 +194,7 @@ int func_01F6FBA0_hospital_f_01(void) { //when you enter the elevator from the s
         D_01F71690_hospital_f_01 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     D_01F71690_hospital_f_01 += shGetDT();
     switch (D_01F71688_hospital_f_01) {
@@ -202,7 +202,7 @@ int func_01F6FBA0_hospital_f_01(void) { //when you enter the elevator from the s
             if (D_01F71690_hospital_f_01 < 0.5f) {
                 return ret;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F71688_hospital_f_01 += 1;
         case 1:
             if (D_01F71690_hospital_f_01 < 1.5f) {

--- a/silent-hill-3/src/Event/stage/hospital_f_01.c
+++ b/silent-hill-3/src/Event/stage/hospital_f_01.c
@@ -194,7 +194,7 @@ int func_01F6FBA0_hospital_f_01(void) { //when you enter the elevator from the s
         D_01F71690_hospital_f_01 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     D_01F71690_hospital_f_01 += shGetDT();
     switch (D_01F71688_hospital_f_01) {
@@ -202,7 +202,7 @@ int func_01F6FBA0_hospital_f_01(void) { //when you enter the elevator from the s
             if (D_01F71690_hospital_f_01 < 0.5f) {
                 return ret;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F71688_hospital_f_01 += 1;
         case 1:
             if (D_01F71690_hospital_f_01 < 1.5f) {

--- a/silent-hill-3/src/Event/stage/hospital_f_01.h
+++ b/silent-hill-3/src/Event/stage/hospital_f_01.h
@@ -27,7 +27,7 @@ int func_002A47C0(float, float);
 int GetExtraNewGame(void);
 int GetRiddleLevel(void);
 int RoomName(void);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 float shGetDT(void);
 int shRandI(void);
 void func_001DE5B0(int*, int, int);

--- a/silent-hill-3/src/Event/stage/hospital_f_02.c
+++ b/silent-hill-3/src/Event/stage/hospital_f_02.c
@@ -139,7 +139,7 @@ int func_01F6E3A0_hospital_f_02(void) {
         D_01F6FF88_hospital_f_02 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(0x4A59, 0.0f, 1.0f);
+        SeCall(19033, 0.0f, 1.0f);
     }
     D_01F6FF88_hospital_f_02 += shGetDT();
     switch (D_01F6FF80_hospital_f_02) { 
@@ -147,7 +147,7 @@ int func_01F6E3A0_hospital_f_02(void) {
             if (D_01F6FF88_hospital_f_02 < 0.5f) {
                 return 0;
             }
-            SeCall(0x4A58, 0.0f, 1.0f);
+            SeCall(19032, 0.0f, 1.0f);
             D_01F6FF80_hospital_f_02 += 1;
         case 1:
             if (D_01F6FF88_hospital_f_02 < 1.5f) {

--- a/silent-hill-3/src/Event/stage/hospital_f_02.c
+++ b/silent-hill-3/src/Event/stage/hospital_f_02.c
@@ -128,6 +128,7 @@ INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_f_02", func_01F6DEC0_hospital
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_f_02", func_01F6E200_hospital_f_02);
 
+#ifdef HOLY_CANDLE
 int func_01F6E3A0_hospital_f_02(void) {
     int ret;
 
@@ -138,7 +139,7 @@ int func_01F6E3A0_hospital_f_02(void) {
         D_01F6FF88_hospital_f_02 = 0.0f;
         func_001C2290(3, 1.5f);
         func_0016C1A0();
-        SeCall(1.0f, 0.0f, 0x4A59);
+        SeCall(0x4A59, 0.0f, 1.0f);
     }
     D_01F6FF88_hospital_f_02 += shGetDT();
     switch (D_01F6FF80_hospital_f_02) { 
@@ -146,7 +147,7 @@ int func_01F6E3A0_hospital_f_02(void) {
             if (D_01F6FF88_hospital_f_02 < 0.5f) {
                 return 0;
             }
-            SeCall(1.0f, 0.0f, 0x4A58);
+            SeCall(0x4A58, 0.0f, 1.0f);
             D_01F6FF80_hospital_f_02 += 1;
         case 1:
             if (D_01F6FF88_hospital_f_02 < 1.5f) {
@@ -164,6 +165,9 @@ int func_01F6E3A0_hospital_f_02(void) {
         }
     return ret;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_f_02", func_01F6E3A0_hospital_f_02);
+#endif
 
 int func_01F6E550_hospital_f_02(void) {
     if (!GET_BIT(D_1D31688, 0x13)) {

--- a/silent-hill-3/src/Event/stage/hospital_f_02.h
+++ b/silent-hill-3/src/Event/stage/hospital_f_02.h
@@ -23,7 +23,7 @@ void func_0029F330(float*, float*);
 int func_002A47C0(float, float);
 void func_01F6D680_hospital_f_02(void);
 int RoomName(void);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 float shGetDT(void);
 void func_001DE5B0(int*, int, int);
 void func_01F6DBD0_hospital_f_02(void);

--- a/silent-hill-3/src/Event/stage/hospital_f_03.c
+++ b/silent-hill-3/src/Event/stage/hospital_f_03.c
@@ -26,7 +26,7 @@ int func_01F6D680_hospital_f_03(void) {
             }
             
             func_00317490(0xC, 0.2f);        
-            SeCall(0x2B21, 0.0f, 1.0f);
+            SeCall(11041, 0.0f, 1.0f);
             D_1D31680 |= 0x80;
             D_01F70910_hospital_f_03 = 2;  
         

--- a/silent-hill-3/src/Event/stage/hospital_f_03.c
+++ b/silent-hill-3/src/Event/stage/hospital_f_03.c
@@ -4,6 +4,7 @@
 UNCURSE_HOSPITAL_MOON();
 #pragma supress_warnings off
 
+#ifdef HOLY_CANDLE
 int func_01F6D680_hospital_f_03(void) {
     int ret;
 
@@ -25,7 +26,7 @@ int func_01F6D680_hospital_f_03(void) {
             }
             
             func_00317490(0xC, 0.2f);        
-            SeCall(1.0f, 0.0f, 0x2B21);
+            SeCall(0x2B21, 0.0f, 1.0f);
             D_1D31680 |= 0x80;
             D_01F70910_hospital_f_03 = 2;  
         
@@ -55,6 +56,9 @@ int func_01F6D680_hospital_f_03(void) {
     }
     return ret;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_f_03", func_01F6D680_hospital_f_03);
+#endif
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/hospital_f_03", func_01F6D840_hospital_f_03);
 

--- a/silent-hill-3/src/Event/stage/hospital_f_03.h
+++ b/silent-hill-3/src/Event/stage/hospital_f_03.h
@@ -21,7 +21,7 @@ void func_00317420(u_int);
 void func_00317490(int, float);
 void func_003174B0(float);
 int func_001DE5B0(int*, int, int);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 int shRandI(void);
 int func_01F6E3B0_hospital_f_03(void);
 int func_01F6E440_hospital_f_03(void*);

--- a/silent-hill-3/src/Event/stage/mall_b_01.c
+++ b/silent-hill-3/src/Event/stage/mall_b_01.c
@@ -53,7 +53,7 @@ int func_01F6D860_mall_b_01(void) {
         if (!func_0016CB70()) {
             SET_BIT(D_1D31654, 0x1A);
             SET_BIT(D_1D31654, 0x1B);
-            SeCall(0x300E, 0.0f, 1.0f);
+            SeCall(12302, 0.0f, 1.0f);
         }
     } 
     else if (GET_BIT(D_1D31654, 0x1B)) {
@@ -62,7 +62,7 @@ int func_01F6D860_mall_b_01(void) {
         }
         if (!func_0016CB70()) {
             UNSET_BIT(D_1D31654, 0x1B);
-            SeCall(0x300E, 0.0f, 1.0f);
+            SeCall(12302, 0.0f, 1.0f);
             if (GET_BIT(D_01D31640, 0x1F) && !GET_BIT(D_1D31654, 0x1C)) {
                 SET_BIT(D_1D31654, 0x1C);
             }
@@ -74,7 +74,7 @@ int func_01F6D860_mall_b_01(void) {
         }
         if (!func_0016CB70()) {
             SET_BIT(D_1D31654, 0x1B);
-            SeCall(0x300E, 0.0f, 1.0f);
+            SeCall(12302, 0.0f, 1.0f);
         }
     }
 

--- a/silent-hill-3/src/Event/stage/mall_b_01.c
+++ b/silent-hill-3/src/Event/stage/mall_b_01.c
@@ -39,6 +39,7 @@ int func_01F6D7A0_mall_b_01(void) {
     return 0; 
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6D860_mall_b_01(void) {
     if (!GET_BIT(D_1D31654, 0x19)) {
         func_00190A20(2);
@@ -52,7 +53,7 @@ int func_01F6D860_mall_b_01(void) {
         if (!func_0016CB70()) {
             SET_BIT(D_1D31654, 0x1A);
             SET_BIT(D_1D31654, 0x1B);
-            SeCall(1.0f, 0.0f, 0x300E);
+            SeCall(0x300E, 0.0f, 1.0f);
         }
     } 
     else if (GET_BIT(D_1D31654, 0x1B)) {
@@ -61,7 +62,7 @@ int func_01F6D860_mall_b_01(void) {
         }
         if (!func_0016CB70()) {
             UNSET_BIT(D_1D31654, 0x1B);
-            SeCall(1.0f, 0.0f, 0x300E);
+            SeCall(0x300E, 0.0f, 1.0f);
             if (GET_BIT(D_01D31640, 0x1F) && !GET_BIT(D_1D31654, 0x1C)) {
                 SET_BIT(D_1D31654, 0x1C);
             }
@@ -73,7 +74,7 @@ int func_01F6D860_mall_b_01(void) {
         }
         if (!func_0016CB70()) {
             SET_BIT(D_1D31654, 0x1B);
-            SeCall(1.0f, 0.0f, 0x300E);
+            SeCall(0x300E, 0.0f, 1.0f);
         }
     }
 
@@ -82,6 +83,9 @@ int func_01F6D860_mall_b_01(void) {
     
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/mall_b_01", func_01F6D860_mall_b_01);
+#endif
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/mall_b_01", func_01F6DA50_mall_b_01);
 

--- a/silent-hill-3/src/Event/stage/mall_b_01.h
+++ b/silent-hill-3/src/Event/stage/mall_b_01.h
@@ -39,7 +39,7 @@ unk_struct* func_00190AC0();
 void func_01F6DF60_mall_b_01(void*);
 void func_01F6E0F0_mall_b_01();
 
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 int func_0016CB70(void);
 int func_0016C1C0(int);
 extern u_int D_01D31640;

--- a/silent-hill-3/src/Event/stage/mall_b_02.c
+++ b/silent-hill-3/src/Event/stage/mall_b_02.c
@@ -25,7 +25,7 @@ extern void func_003174B0(float);
 extern int func_00168440(void);
 extern int func_0016C1C0(int);
 extern void func_00317490(int, float);
-extern int SeCall(float, float, int);
+extern int SeCall(int, float, float);
 extern void func_00317420(int);
 extern void func_0016C3C0(void);
 extern void func_0018FE60(u_long128*);
@@ -103,6 +103,7 @@ int func_01F6D680_mall_b_02(void) {
     return ret;
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6D820_mall_b_02(void) {
     if (!(D_1D31658 & 1)) {
         func_00317420(0x2F);
@@ -123,7 +124,7 @@ int func_01F6D820_mall_b_02(void) {
             func_00317490(0x2F, 0.2f);
             D_1D31658 |= 2;
             func_0016C3C0();
-            SeCall(1.0f, 0.0f, 0x2B21);
+            SeCall(0x2B21, 0.0f, 1.0f);
 
         default:
             if (!func_0016C1C0(0x21)) {
@@ -136,6 +137,9 @@ int func_01F6D820_mall_b_02(void) {
     D_1D31658 &= ~1;
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/mall_b_02", func_01F6D820_mall_b_02);
+#endif
 
 int func_01F6D970_mall_b_02(void) {
     if (!((D_1D31658 >> 2) & 1)) {
@@ -167,13 +171,14 @@ int func_01F6D970_mall_b_02(void) {
     return 1;
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6DA80_mall_b_02(void) {
     sceVu0FVECTOR  sp10;
 
     switch (D_01F6E8B0_mall_b_02) {
         case 0:
             func_0018FE60((u_long128*)&sp10);
-            SeCall(1.0f, 0.0f, 0x3070);
+            SeCall(0x3070, 0.0f, 1.0f);
             func_001C2290(3, 0.5f);
             func_0016C1A0();
             D_1D31658 |= 8;
@@ -197,6 +202,9 @@ int func_01F6DA80_mall_b_02(void) {
             return 1;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/mall_b_02", func_01F6DA80_mall_b_02);
+#endif
 
 int func_01F6DBC0_mall_b_02(void) {
     unk_01F6E890_mall_b_02_struct* p = &D_01F6E890_mall_b_02;   

--- a/silent-hill-3/src/Event/stage/mall_b_02.c
+++ b/silent-hill-3/src/Event/stage/mall_b_02.c
@@ -124,7 +124,7 @@ int func_01F6D820_mall_b_02(void) {
             func_00317490(0x2F, 0.2f);
             D_1D31658 |= 2;
             func_0016C3C0();
-            SeCall(0x2B21, 0.0f, 1.0f);
+            SeCall(11041, 0.0f, 1.0f);
 
         default:
             if (!func_0016C1C0(0x21)) {
@@ -178,7 +178,7 @@ int func_01F6DA80_mall_b_02(void) {
     switch (D_01F6E8B0_mall_b_02) {
         case 0:
             func_0018FE60((u_long128*)&sp10);
-            SeCall(0x3070, 0.0f, 1.0f);
+            SeCall(12400, 0.0f, 1.0f);
             func_001C2290(3, 0.5f);
             func_0016C1A0();
             D_1D31658 |= 8;

--- a/silent-hill-3/src/Event/stage/mall_f_00.c
+++ b/silent-hill-3/src/Event/stage/mall_f_00.c
@@ -261,7 +261,7 @@ int func_01F6DEF0_mall_f_00(void)
         D_01F6FBD8_mall_f_00 = shRandF();
         SET_BIT(D_1D3164C, 18);
         func_00190A20(2);
-        SeCall(0x2EE0, 0.0f, 1.0f);
+        SeCall(12000, 0.0f, 1.0f);
     }
 
     switch (D_01F6FBE8_mall_f_00)
@@ -272,7 +272,7 @@ int func_01F6DEF0_mall_f_00(void)
                 return 0;
             }
 
-            SeCall(0x2EE1, 0.0f, 1.0f);
+            SeCall(12001, 0.0f, 1.0f);
             D_01F6FBE0_mall_f_00 = 0.0f;
             ++D_01F6FBE8_mall_f_00;
             /* fallthrough */

--- a/silent-hill-3/src/Event/stage/mall_f_00.c
+++ b/silent-hill-3/src/Event/stage/mall_f_00.c
@@ -251,6 +251,7 @@ void func_01F6DE40_mall_f_00(void)
     }
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6DEF0_mall_f_00(void)
 {
     if (!GET_BIT(D_1D3164C, 18))
@@ -260,7 +261,7 @@ int func_01F6DEF0_mall_f_00(void)
         D_01F6FBD8_mall_f_00 = shRandF();
         SET_BIT(D_1D3164C, 18);
         func_00190A20(2);
-        SeCall(1.0f, 0.0f, 0x2EE0);
+        SeCall(0x2EE0, 0.0f, 1.0f);
     }
 
     switch (D_01F6FBE8_mall_f_00)
@@ -271,7 +272,7 @@ int func_01F6DEF0_mall_f_00(void)
                 return 0;
             }
 
-            SeCall(1.0f, 0.0f, 0x2EE1);
+            SeCall(0x2EE1, 0.0f, 1.0f);
             D_01F6FBE0_mall_f_00 = 0.0f;
             ++D_01F6FBE8_mall_f_00;
             /* fallthrough */
@@ -297,6 +298,9 @@ int func_01F6DEF0_mall_f_00(void)
             return 1;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/mall_f_00", func_01F6DEF0_mall_f_00);
+#endif
 
 int func_01F6E0C0_mall_f_00(void)
 {

--- a/silent-hill-3/src/Event/stage/mall_f_00.h
+++ b/silent-hill-3/src/Event/stage/mall_f_00.h
@@ -50,7 +50,7 @@ void func_00316C50(int);
 void func_0016ECE0(int);
 float shRandF(void);
 int func_00190A20(int);
-void SeCall(float, float, int);
+void SeCall(int, float, float);
 float shGetDT(void);
 int func_0016C1C0(int);
 void func_0016C3C0(void);

--- a/silent-hill-3/src/Event/stage/mall_f_01.c
+++ b/silent-hill-3/src/Event/stage/mall_f_01.c
@@ -136,7 +136,7 @@ int func_01F6DA70_mall_f_01(void)
             }
 
             func_0016C3C0();
-            SeCall(0x2B21, 0.0f, 1.0f);
+            SeCall(11041, 0.0f, 1.0f);
             ItemGet(5);
             SET_BIT(D_1D3164C, 25);
             func_00317490(5, 0.2f);

--- a/silent-hill-3/src/Event/stage/mall_f_01.c
+++ b/silent-hill-3/src/Event/stage/mall_f_01.c
@@ -111,6 +111,7 @@ int func_01F6DA20_mall_f_01(void)
     return ret;
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6DA70_mall_f_01(void)
 {
     if (!GET_BIT(D_1D3164C, 24))
@@ -135,7 +136,7 @@ int func_01F6DA70_mall_f_01(void)
             }
 
             func_0016C3C0();
-            SeCall(1.0f, 0.0f, 0x2B21);
+            SeCall(0x2B21, 0.0f, 1.0f);
             ItemGet(5);
             SET_BIT(D_1D3164C, 25);
             func_00317490(5, 0.2f);
@@ -156,6 +157,9 @@ int func_01F6DA70_mall_f_01(void)
 
     return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/mall_f_01", func_01F6DA70_mall_f_01);
+#endif
 
 int func_01F6DBD0_mall_f_01(void)
 {

--- a/silent-hill-3/src/Event/stage/mall_f_01.h
+++ b/silent-hill-3/src/Event/stage/mall_f_01.h
@@ -36,7 +36,7 @@ void func_00317420(int);
 int func_00190A20(int);
 int func_0016C1C0(int);
 int func_00168440(void);
-void SeCall(float, float, int);
+void SeCall(int, float, float);
 void ItemGet(u_int);
 void func_00317490(int, float);
 void func_003174B0(float);

--- a/silent-hill-3/src/Event/stage/sewer_00.c
+++ b/silent-hill-3/src/Event/stage/sewer_00.c
@@ -87,14 +87,14 @@ int func_01F6D980_sewer_00(void) {
     func_00190A20(2);
     D_01F6FE60_sewer_00++;
     func_00317420(0x34);
-    SeCall(0x2B21, 0.0f, 1.0f);
+    SeCall(11041, 0.0f, 1.0f);
   case 1:
     if (func_0016C1C0(0x45) == 0) {
       return 0;
     }
     func_0016C3C0();
     D_01F6FE60_sewer_00++;
-    SeCall(0x2B21, 0.0f, 1.0f);
+    SeCall(11041, 0.0f, 1.0f);
     func_00317490(0x34, 0.2f);
   case 2:
     if (func_0016C1C0(0x46) == 0) {
@@ -140,7 +140,7 @@ int func_01F6DAB0_sewer_00(void) {
           func_0013D250(0, D_01F6F9F0_sewer_00, 1.0f);
           D_1D31664 |= 4;
           func_00316C50(0);
-          SeCall(0x3200, 0.0f, 1.0f);
+          SeCall(12800, 0.0f, 1.0f);
           D_01F6FE30_sewer_00 = func_0016E0F0();
           continue;
         }

--- a/silent-hill-3/src/Event/stage/sewer_00.c
+++ b/silent-hill-3/src/Event/stage/sewer_00.c
@@ -79,6 +79,7 @@ int func_01F6D870_sewer_00(void) {
   }
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6D980_sewer_00(void) {
   switch (D_01F6FE60_sewer_00) {
   case 0:
@@ -86,14 +87,14 @@ int func_01F6D980_sewer_00(void) {
     func_00190A20(2);
     D_01F6FE60_sewer_00++;
     func_00317420(0x34);
-    SeCall(1.0f, 0.0f, 0x2B21);
+    SeCall(0x2B21, 0.0f, 1.0f);
   case 1:
     if (func_0016C1C0(0x45) == 0) {
       return 0;
     }
     func_0016C3C0();
     D_01F6FE60_sewer_00++;
-    SeCall(1.0f, 0.0f, 0x2B21);
+    SeCall(0x2B21, 0.0f, 1.0f);
     func_00317490(0x34, 0.2f);
   case 2:
     if (func_0016C1C0(0x46) == 0) {
@@ -108,7 +109,11 @@ int func_01F6D980_sewer_00(void) {
 
   return 1;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/sewer_00", func_01F6D980_sewer_00);
+#endif
 
+#ifdef HOLY_CANDLE
 int func_01F6DAB0_sewer_00(void) {
   sceVu0FMATRIX sp10;
   SubCharacter *heather;
@@ -135,7 +140,7 @@ int func_01F6DAB0_sewer_00(void) {
           func_0013D250(0, D_01F6F9F0_sewer_00, 1.0f);
           D_1D31664 |= 4;
           func_00316C50(0);
-          SeCall(1.0f, 0.0f, 0x3200);
+          SeCall(0x3200, 0.0f, 1.0f);
           D_01F6FE30_sewer_00 = func_0016E0F0();
           continue;
         }
@@ -197,6 +202,9 @@ int func_01F6DAB0_sewer_00(void) {
     }
   }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/sewer_00", func_01F6DAB0_sewer_00);
+#endif
 
 INCLUDE_ASM("asm/nonmatchings/Event/stage/sewer_00", func_01F6DE40_sewer_00);
 

--- a/silent-hill-3/src/Event/stage/sewer_00.h
+++ b/silent-hill-3/src/Event/stage/sewer_00.h
@@ -41,7 +41,7 @@ void func_00317490(int, float);
 void func_003174B0(float);
 int RoomName(void);
 u_char GetActionLevel(void);
-int SeCall(float, float, int);
+int SeCall(int, float, float);
 
 extern int D_01F6F8F0_sewer_00[];
 extern int D_01F6F850_sewer_00[];

--- a/silent-hill-3/src/Event/stage/subway_01.c
+++ b/silent-hill-3/src/Event/stage/subway_01.c
@@ -94,7 +94,7 @@ int func_01F6D720_subway_01(void)
         case 0:
             func_00190A20(2);
             func_001C2290(3, 0.5f);
-            SeCall(0x3139, 0.0f, 1.0f);
+            SeCall(12601, 0.0f, 1.0f);
             func_01F6E2D0_subway_01();
             func_0013D250(0, &D_01F70180_subway_01, 1.0f);
             D_01F70700_subway_01 = 1;
@@ -216,7 +216,7 @@ int func_01F6DBE0_subway_01(void)
             }
 
             D_1D31648 |= 0x40000;
-            SeCall(0x3139, 0.0f, 1.0f);
+            SeCall(12601, 0.0f, 1.0f);
             ++D_01F70700_subway_01;
             /* fallthrough */
         case 1:
@@ -684,7 +684,7 @@ void func_01F6E960_subway_01(void)
             switch (D_01F70720_subway_01)
             {
                 case 0:
-                    SeCall(0x3139, 0.0f, 0.2f);
+                    SeCall(12601, 0.0f, 0.2f);
                     D_01F70730_subway_01 = 0.0f;
                     ++D_01F70720_subway_01;
                     break;
@@ -693,7 +693,7 @@ void func_01F6E960_subway_01(void)
 
                     if (D_01F70730_subway_01 > 20.0f)
                     {
-                        SeCall(0x3139, 0.0f, 0.6f);
+                        SeCall(12601, 0.0f, 0.6f);
                         ++D_01F70720_subway_01;
                     }
 
@@ -736,7 +736,7 @@ void func_01F6E960_subway_01(void)
 
                     if (D_01F70728_subway_01 > 50.0f)
                     {
-                        SeCall(0x3139, 0.0f, 0.6f);
+                        SeCall(12601, 0.0f, 0.6f);
                         ++D_01F70708_subway_01;
                     }
 
@@ -757,7 +757,7 @@ void func_01F6E960_subway_01(void)
                 case 4:
                     D_01F70708_subway_01 = 5;
                     D_01F70728_subway_01 = 0.0f;
-                    SeCall(0x3139, 0.0f, 0.6f);
+                    SeCall(12601, 0.0f, 0.6f);
                     break;
                 case 5:
                     D_01F70728_subway_01 += shGetDT();

--- a/silent-hill-3/src/Event/stage/subway_01.c
+++ b/silent-hill-3/src/Event/stage/subway_01.c
@@ -31,6 +31,7 @@ int func_01F6D690_subway_01(void)
     return var_s0;
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6D720_subway_01(void)
 {
     int var_s0 = 0;
@@ -93,7 +94,7 @@ int func_01F6D720_subway_01(void)
         case 0:
             func_00190A20(2);
             func_001C2290(3, 0.5f);
-            SeCall(1.0f, 0.0f, 0x3139);
+            SeCall(0x3139, 0.0f, 1.0f);
             func_01F6E2D0_subway_01();
             func_0013D250(0, &D_01F70180_subway_01, 1.0f);
             D_01F70700_subway_01 = 1;
@@ -158,6 +159,9 @@ int func_01F6D720_subway_01(void)
 
     return var_s0;
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/subway_01", func_01F6D720_subway_01);
+#endif
 
 int func_01F6DAA0_subway_01(void)
 {
@@ -197,6 +201,7 @@ int func_01F6DAA0_subway_01(void)
     return var_s0;
 }
 
+#ifdef HOLY_CANDLE
 int func_01F6DBE0_subway_01(void)
 {
     int var_s0 = 0;
@@ -211,7 +216,7 @@ int func_01F6DBE0_subway_01(void)
             }
 
             D_1D31648 |= 0x40000;
-            SeCall(1.0f, 0.0f, 0x3139);
+            SeCall(0x3139, 0.0f, 1.0f);
             ++D_01F70700_subway_01;
             /* fallthrough */
         case 1:
@@ -244,6 +249,9 @@ int func_01F6DBE0_subway_01(void)
             return var_s0;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/subway_01", func_01F6DBE0_subway_01);
+#endif
 
 int func_01F6DD70_subway_01(void)
 {
@@ -658,6 +666,7 @@ void func_01F6E900_subway_01(Q* arg0, int* arg1, Q* arg2, int* arg3, int* arg4)
     *arg4 = 0;
 }
 
+#ifdef HOLY_CANDLE
 void func_01F6E960_subway_01(void)
 {
     short temp_s0;
@@ -675,7 +684,7 @@ void func_01F6E960_subway_01(void)
             switch (D_01F70720_subway_01)
             {
                 case 0:
-                    SeCall(0.2f, 0.0f, 0x3139);
+                    SeCall(0x3139, 0.0f, 0.2f);
                     D_01F70730_subway_01 = 0.0f;
                     ++D_01F70720_subway_01;
                     break;
@@ -684,7 +693,7 @@ void func_01F6E960_subway_01(void)
 
                     if (D_01F70730_subway_01 > 20.0f)
                     {
-                        SeCall(0.6f, 0.0f, 0x3139);
+                        SeCall(0x3139, 0.0f, 0.6f);
                         ++D_01F70720_subway_01;
                     }
 
@@ -727,7 +736,7 @@ void func_01F6E960_subway_01(void)
 
                     if (D_01F70728_subway_01 > 50.0f)
                     {
-                        SeCall(0.6f, 0.0f, 0x3139);
+                        SeCall(0x3139, 0.0f, 0.6f);
                         ++D_01F70708_subway_01;
                     }
 
@@ -748,7 +757,7 @@ void func_01F6E960_subway_01(void)
                 case 4:
                     D_01F70708_subway_01 = 5;
                     D_01F70728_subway_01 = 0.0f;
-                    SeCall(0.6f, 0.0f, 0x3139);
+                    SeCall(0x3139, 0.0f, 0.6f);
                     break;
                 case 5:
                     D_01F70728_subway_01 += shGetDT();
@@ -768,3 +777,6 @@ void func_01F6E960_subway_01(void)
         }
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Event/stage/subway_01", func_01F6E960_subway_01);
+#endif

--- a/silent-hill-3/src/Event/stage/subway_01.h
+++ b/silent-hill-3/src/Event/stage/subway_01.h
@@ -54,7 +54,7 @@ short RoomName(void);
 void func_001908A0(float*, float*);
 void func_001DC9E0(SubCharacter*, int);
 void func_001C2290(int, float);
-void SeCall(float, float, int);
+void SeCall(int, float, float);
 void func_0013D250(int, int*, float);
 int func_0016C540(int*, int*);
 float func_001643C0(void);

--- a/silent-hill-3/src/Font/font.c
+++ b/silent-hill-3/src/Font/font.c
@@ -413,18 +413,22 @@ void func_0015CF10(u_short *dest, u_short *src) {
     } while (n != 0xFFFF);
 }
 
+#ifdef HOLY_CANDLE
 void fontPushButton()
 {
     if (font.wait_type == 4) {
         font.st_num = 0;
         font.wait_type = 5;
-        SeCall(1.0f, 0.0f, 0x2712);
+        SeCall(0x2712, 0.0f, 1.0f);
         return;
     }
     if (((font.wait_type & 7u) != 2) && !(font.flag & 0x10)) {
         font.wait_count = 0;
     }
 }
+#else
+INCLUDE_ASM("asm/nonmatchings/Font/font", fontPushButton);
+#endif
 
 void fontPushButton2()
 {
@@ -450,7 +454,7 @@ void fontSelectUp()
                 font.sel_now = font.sel_max - 1;
             }
         }
-        SeCall(1.0f, 0.0f, 10000);
+        SeCall(10000, 0.0f, 1.0f);
     }
 }
 
@@ -468,7 +472,7 @@ void fontSelectDown()
         {
             font.sel_now = 0;
         }
-        SeCall(1.0f, 0.0f, 10000);
+        SeCall(10000, 0.0f, 1.0f);
     }
 }
 #else

--- a/silent-hill-3/src/Font/font.h
+++ b/silent-hill-3/src/Font/font.h
@@ -91,7 +91,7 @@ extern short D_003585A8[20][2];
 extern short D_003585AA[20][2];
 extern u_long font_dma_data[34];
 extern char D_01D08FB0[FONT_STREAM_BUFFER_SIZE];
-extern int SeCall(int arg0, float arg1, float arg2);
+extern int SeCall(int, float, float);
 int fontLoad(u_short code);
 void fontClear(void);
 void fontSetStreamMax(u_short s_max, u_short ws_max, u_short ms_max);

--- a/silent-hill-3/src/Font/font.h
+++ b/silent-hill-3/src/Font/font.h
@@ -91,7 +91,7 @@ extern short D_003585A8[20][2];
 extern short D_003585AA[20][2];
 extern u_long font_dma_data[34];
 extern char D_01D08FB0[FONT_STREAM_BUFFER_SIZE];
-extern int SeCall(float arg0, float arg1, int arg2);
+extern int SeCall(int arg0, float arg1, float arg2);
 int fontLoad(u_short code);
 void fontClear(void);
 void fontSetStreamMax(u_short s_max, u_short ws_max, u_short ms_max);


### PR DESCRIPTION
thanks to mwcc holy candle rituals, this pr drops perfect match by around 0.8% >_> though it keeps fuzzy about the same

sh2's `SeCall` is found in the debug info as 

```c
int SeCall(int sd_no, float volume, int stereo); 
```

but the sh3 equivalent has two floats and one int, and the int is the sound id.. so it'd make sense for sh3 to have `int SeCall(int sd_no, float volume, float stereo)`.

unfortunately since the calling convention doesn't distinguish between `SeCall(int, float, float)` and `SeCall(float, float, int)`, we happened to pick the second one as it seemed to match more easily. but, mwcc being mwcc, the matching behavior is effectively random...
